### PR TITLE
Timelock error message propagation

### DIFF
--- a/contracts/governance/Timelock.sol
+++ b/contracts/governance/Timelock.sol
@@ -97,7 +97,13 @@ contract Timelock {
 
         // solium-disable-next-line security/no-call-value
         (bool success, bytes memory returnData) = target.call.value(value)(callData);
-        require(success, "Timelock::executeTransaction: Transaction execution reverted.");
+        if (!success) {
+            if (returnData.length == 0) {
+                revert("Timelock::executeTransaction: Transaction execution reverted.");
+            } else {
+                revert(strConcat("Timelock::executeTransaction: ", string(returnData)));
+            }
+        }
 
         emit ExecuteTransaction(txHash, target, value, signature, data, eta);
 
@@ -108,4 +114,21 @@ contract Timelock {
         // solium-disable-next-line security/no-block-members
         return block.timestamp;
     }
+    
+    function strConcat(string memory str1, string memory str2) internal pure returns (string memory) {
+        uint returnDataShift = 68; //TODO check
+        bytes memory bytesStr1 = bytes(str1);
+        bytes memory bytesStr2 = bytes(str2);
+        string memory str12 = new string(bytesStr1.length + bytesStr2.length - returnDataShift);
+        bytes memory bytesStr12 = bytes(str12);
+        uint j = 0;
+        for (uint i = 0; i < bytesStr1.length; i++) {
+            bytesStr12[j++] = bytesStr1[i];
+        }
+        for (uint i = returnDataShift; i < bytesStr2.length; i++) {
+            bytesStr12[j++] = bytesStr2[i];
+        }
+        return string(bytesStr12);
+    }
+    
 }

--- a/tests-js/Governance/GovernanceIntegrationTest.js
+++ b/tests-js/Governance/GovernanceIntegrationTest.js
@@ -31,8 +31,6 @@ const TWO_DAYS = 86400 * 2;
 const TWO_WEEKS = 86400 * 14;
 const MAX_DURATION = new BN(24 * 60 * 60).mul(new BN(1092));
 
-//TODO require(success, "Timelock::executeTransaction: Transaction execution reverted.");
-
 contract('GovernanceIntegration', accounts => {
     const name = 'Test token';
     const symbol = 'TST';

--- a/tests-js/TimelockTest.js
+++ b/tests-js/TimelockTest.js
@@ -249,7 +249,7 @@ contract('Timelock', accounts => {
             
             await setTime(eta.toNumber());
             await expectRevert(timelock.executeTransaction(target, value, signature, revertData, eta, {from: root}),
-                'revert Timelock::executeTransaction: Transaction execution reverted.');
+                'revert Timelock::executeTransaction: Timelock::setDelay: Delay must exceed minimum delay.');
         });
         
         it('sets hash from true to false in queuedTransactions mapping, updates delay, and emits ExecuteTransaction event', async () => {


### PR DESCRIPTION
Error message wasn't propagated, so we had the following message for all failed transactions:
`Timelock::executeTransaction: Transaction execution reverted.`

With error message propagation:
`Timelock::executeTransaction: Timelock::setDelay: Delay must exceed minimum delay.`
`Timelock::executeTransaction: unauthorized`
