### PR TITLE
Proxy eip 1967

### DIFF
--- a/contracts/proxy/Proxy.sol
+++ b/contracts/proxy/Proxy.sol
@@ -16,8 +16,8 @@ contract Proxy {
 	/// According to EIP-1967 standard.
 	bytes32 private constant KEY_OWNER = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
 
-	event OwnershipTransferred(address indexed _oldOwner, address indexed _newOwner);
-	event ImplementationChanged(address indexed _oldImplementation, address indexed _newImplementation);
+	event AdminChanged(address previousAdmin, address newAdmin);
+	event Upgraded(address indexed implementation);
 
 	/**
 	 * @notice Sets sender as an owner
@@ -59,7 +59,7 @@ contract Proxy {
 
 	function _setProxyOwner(address _owner) internal {
 		require(_owner != address(0), "Proxy::setProxyOwner: invalid address");
-		
+
 		/// @dev EIP-1967 standard event log.
 		emit AdminChanged(getProxyOwner(), _owner);
 

--- a/contracts/proxy/Proxy.sol
+++ b/contracts/proxy/Proxy.sol
@@ -4,8 +4,17 @@ pragma solidity ^0.5.17;
  * @title Base Proxy Contract
  */
 contract Proxy {
-	bytes32 private constant KEY_IMPLEMENTATION = keccak256("key.implementation");
-	bytes32 private constant KEY_OWNER = keccak256("key.proxy.owner");
+	/// @dev The storage slot 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
+	/// (obtained as bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1))
+	/// should hold the address of the logic contract that the proxy delegates to.
+	/// According to EIP-1967 standard.
+	bytes32 private constant KEY_IMPLEMENTATION = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+	/// @dev The storage slot 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103
+	/// (obtained as bytes32(uint256(keccak256('eip1967.proxy.admin')) - 1))
+	/// should hold the address that is allowed to upgrade the logic contract address.
+	/// According to EIP-1967 standard.
+	bytes32 private constant KEY_OWNER = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
 
 	event OwnershipTransferred(address indexed _oldOwner, address indexed _newOwner);
 	event ImplementationChanged(address indexed _oldImplementation, address indexed _newImplementation);
@@ -27,7 +36,9 @@ contract Proxy {
 
 	function _setImplementation(address _implementation) internal {
 		require(_implementation != address(0), "Proxy::setImplementation: invalid address");
-		emit ImplementationChanged(getImplementation(), _implementation);
+
+		/// @dev EIP-1967 standard event log.
+		emit Upgraded(_implementation);
 
 		bytes32 key = KEY_IMPLEMENTATION;
 		assembly {
@@ -48,7 +59,9 @@ contract Proxy {
 
 	function _setProxyOwner(address _owner) internal {
 		require(_owner != address(0), "Proxy::setProxyOwner: invalid address");
-		emit OwnershipTransferred(getProxyOwner(), _owner);
+		
+		/// @dev EIP-1967 standard event log.
+		emit AdminChanged(getProxyOwner(), _owner);
 
 		bytes32 key = KEY_OWNER;
 		assembly {

--- a/tests-js/proxy/Proxy.js
+++ b/tests-js/proxy/Proxy.js
@@ -26,9 +26,9 @@ contract("Proxy", (accounts) => {
 	describe("setProxyOwner", async () => {
 		it("Should be able to transfer ownership", async () => {
 			let tx = await proxy.setProxyOwner(account1, { from: accountOwner });
-			expectEvent(tx, "OwnershipTransferred", {
-				_oldOwner: accountOwner,
-				_newOwner: account1,
+			expectEvent(tx, "AdminChanged", {
+				previousAdmin: accountOwner,
+				newAdmin: account1,
 			});
 
 			let owner = await proxy.getProxyOwner.call();
@@ -47,9 +47,8 @@ contract("Proxy", (accounts) => {
 	describe("setImplementation", async () => {
 		it("Should be able to set implementation", async () => {
 			let tx = await proxy.setImplementation(implementation.address, { from: accountOwner });
-			expectEvent(tx, "ImplementationChanged", {
-				_oldImplementation: ZERO_ADDRESS,
-				_newImplementation: implementation.address,
+			expectEvent(tx, "Upgraded", {
+				implementation: implementation.address,
 			});
 
 			let returnedImplementation = await proxy.getImplementation.call();


### PR DESCRIPTION
Proxy contract has been modified to comply with EIP-1967 https://eips.ethereum.org/EIPS/eip-1967 , that basically standardises the storage slot for the logic contract address and for the admin account that is allowed to modify it, if upgradeable (only UpgradableProxy has an external method to do so). It requires also a renaming for the associated events.

Previous code was using slots for both address, but were not the standard ones.