### PR TITLE
Add trader in the payTradingToAffiliate event

### DIFF
--- a/contracts/events/AffiliatesEvents.sol
+++ b/contracts/events/AffiliatesEvents.sol
@@ -14,6 +14,7 @@ contract AffiliatesEvents {
 
 	event PayTradingFeeToAffiliate(
 		address indexed referrer,
+		address trader,
 		address indexed token,
 		bool indexed isHeld,
 		uint256 tradingFeeTokenAmount,
@@ -24,6 +25,7 @@ contract AffiliatesEvents {
 
 	event PayTradingFeeToAffiliateFail(
 		address indexed referrer,
+		address trader,
 		address indexed token,
 		uint256 tradingFeeTokenAmount,
 		uint256 tokenBonusAmount,

--- a/contracts/interfaces/ISovryn.sol
+++ b/contracts/interfaces/ISovryn.sol
@@ -324,6 +324,7 @@ contract ISovryn is
 
 	function payTradingFeeToAffiliatesReferrer(
 		address referrer,
+		address trader,
 		address token,
 		uint256 tradingFeeTokenBaseAmount
 	) external returns (uint256 affiliatesBonusSOVAmount, uint256 affiliatesBonusTokenAmount);

--- a/contracts/mixins/FeesHelper.sol
+++ b/contracts/mixins/FeesHelper.sol
@@ -69,11 +69,12 @@ contract FeesHelper is State, ProtocolTokenUser, FeesEvents {
 
 	function _payTradingFeeToAffiliate(
 		address referrer,
+		address trader,
 		address feeToken,
 		uint256 tradingFee
 	) internal returns (uint256 affiliatesBonusSOVAmount, uint256 affiliatesBonusTokenAmount) {
 		(affiliatesBonusSOVAmount, affiliatesBonusTokenAmount) = ProtocolAffiliatesInterface(protocolAddress)
-			.payTradingFeeToAffiliatesReferrer(referrer, feeToken, tradingFee);
+			.payTradingFeeToAffiliatesReferrer(referrer, trader, feeToken, tradingFee);
 	}
 
 	/**
@@ -92,7 +93,7 @@ contract FeesHelper is State, ProtocolTokenUser, FeesEvents {
 		uint256 protocolTradingFee = tradingFee; //trading fee paid to protocol
 		if (tradingFee != 0) {
 			if (affiliatesUserReferrer[user] != address(0)) {
-				_payTradingFeeToAffiliate(affiliatesUserReferrer[user], feeToken, protocolTradingFee);
+				_payTradingFeeToAffiliate(affiliatesUserReferrer[user], user, feeToken, protocolTradingFee);
 				protocolTradingFee = (protocolTradingFee.sub(protocolTradingFee.mul(affiliateFeePercent).div(10**20))).sub(
 					protocolTradingFee.mul(affiliateTradingTokenFeePercent).div(10**20)
 				);

--- a/contracts/modules/Affiliates.sol
+++ b/contracts/modules/Affiliates.sol
@@ -181,6 +181,7 @@ contract Affiliates is State, AffiliatesEvents {
 		if (bonusPaymentIsSuccess) {
 			emit PayTradingFeeToAffiliate(
 				referrer,
+				tx.origin, // trader
 				token,
 				isHeld,
 				tradingFeeTokenBaseAmount,
@@ -191,6 +192,7 @@ contract Affiliates is State, AffiliatesEvents {
 		} else {
 			emit PayTradingFeeToAffiliateFail(
 				referrer,
+				tx.origin, // trader
 				token,
 				tradingFeeTokenBaseAmount,
 				referrerBonusTokenAmount,

--- a/contracts/modules/Affiliates.sol
+++ b/contracts/modules/Affiliates.sol
@@ -143,6 +143,7 @@ contract Affiliates is State, AffiliatesEvents {
 	 */
 	function payTradingFeeToAffiliatesReferrer(
 		address referrer,
+		address trader,
 		address token,
 		uint256 tradingFeeTokenBaseAmount
 	) external onlyCallableInternal returns (uint256 referrerBonusSovAmount, uint256 referrerBonusTokenAmount) {
@@ -181,7 +182,7 @@ contract Affiliates is State, AffiliatesEvents {
 		if (bonusPaymentIsSuccess) {
 			emit PayTradingFeeToAffiliate(
 				referrer,
-				tx.origin, // trader
+				trader, // trader
 				token,
 				isHeld,
 				tradingFeeTokenBaseAmount,
@@ -192,7 +193,7 @@ contract Affiliates is State, AffiliatesEvents {
 		} else {
 			emit PayTradingFeeToAffiliateFail(
 				referrer,
-				tx.origin, // trader
+				trader, // trader
 				token,
 				tradingFeeTokenBaseAmount,
 				referrerBonusTokenAmount,

--- a/contracts/modules/interfaces/ProtocolAffiliatesInterface.sol
+++ b/contracts/modules/interfaces/ProtocolAffiliatesInterface.sol
@@ -14,6 +14,7 @@ interface ProtocolAffiliatesInterface {
 
 	function payTradingFeeToAffiliatesReferrer(
 		address affiliate,
+		address trader,
 		address token,
 		uint256 amount
 	) external returns (uint256 affiliatesBonusSOVAmount, uint256 affiliatesBonusTokenAmount);

--- a/interfaces/ISovrynBrownie.sol
+++ b/interfaces/ISovrynBrownie.sol
@@ -325,6 +325,7 @@ contract ISovrynBrownie is
 
 	function payTradingFeeToAffiliatesReferrer(
 		address referrer,
+		address trader,
 		address token,
 		uint256 tradingFeeTokenBaseAmount
 	) external returns (uint256 affiliatesBonusSOVAmount, uint256 affiliatesBonusTokenAmount);

--- a/tests-js/affiliates.test.js
+++ b/tests-js/affiliates.test.js
@@ -215,6 +215,7 @@ contract("Affiliates", (accounts) => {
 		tradingFeeAmount = decode[0].args["tradingFeeTokenAmount"];
 		submittedToken = decode[0].args["token"];
 		submittedReferrer = decode[0].args["referrer"];
+		submittedTrader = decode[0].args["trader"];
 		isHeld = decode[0].args["isHeld"];
 		affiliatesFeePercentage = await sovryn.affiliateFeePercent();
 		sovBonusAmountShouldBePaid = await feeds.queryReturn(
@@ -228,6 +229,7 @@ contract("Affiliates", (accounts) => {
 		expect(sovBonusAmountShouldBePaid.toString(), "Incorrect sov bonus amount calculation").to.be.equal(submittedSovBonusAmount);
 		expect(submittedToken).to.eql(doc.address);
 		expect(submittedReferrer).to.eql(referrer);
+		expect(submittedTrader).to.eql(trader);
 		expect(referrerFee.toString()).to.be.equal(submittedTokenBonusAmount.toString());
 		// Since the minimum referrals to payout is set to 3, make sure the affiliateRewardsHeld is correct
 		expect(affiliateRewardsHeld.toString(), "SOV Bonus amount that stored in the affiliateRewardsHeld is incorrect").to.be.equal(
@@ -262,6 +264,7 @@ contract("Affiliates", (accounts) => {
 		tradingFeeAmount = decode[0].args["tradingFeeTokenAmount"];
 		submittedToken = decode[0].args["token"];
 		submittedReferrer = decode[0].args["referrer"];
+		submittedTrader = decode[0].args["trader"];
 		isHeld = decode[0].args["isHeld"];
 		sovBonusAmountShouldBePaid = await feeds.queryReturn(
 			doc.address,
@@ -277,6 +280,7 @@ contract("Affiliates", (accounts) => {
 		);
 		expect(submittedToken).to.eql(doc.address);
 		expect(submittedReferrer).to.eql(referrer);
+		expect(submittedTrader).to.eql(trader);
 
 		expect(
 			new BN(parseInt(previousAffiliateRewardsHeld)).add(new BN(parseInt(sovBonusAmountShouldBePaid))).toString(),
@@ -322,6 +326,7 @@ contract("Affiliates", (accounts) => {
 		tradingFeeAmount = decode[0].args["tradingFeeTokenAmount"];
 		submittedToken = decode[0].args["token"];
 		submittedReferrer = decode[0].args["referrer"];
+		submittedTrader = decode[0].args["trader"];
 		isHeld = decode[0].args["isHeld"];
 		affiliatesFeePercentage = await sovryn.affiliateFeePercent();
 		sovBonusAmountShouldBePaid = await feeds.queryReturn(
@@ -335,6 +340,7 @@ contract("Affiliates", (accounts) => {
 		expect(sovBonusAmountShouldBePaid.toString(), "Incorrect sov bonus amount calculation").to.be.equal(submittedSovBonusAmount);
 		expect(submittedToken).to.eql(doc.address);
 		expect(submittedReferrer).to.eql(referrer);
+		expect(submittedTrader).to.eql(trader);
 		expect(referrerFee.toString()).to.be.equal(submittedTokenBonusAmount.toString());
 		// Since the minimum referrals to payout is set to 1, make sure the affiliateRewardsHeld is correct
 		expect(affiliateRewardsHeld.toString(), "SOV Bonus amount that stored in the affiliateRewardsHeld is incorrect").to.be.equal(
@@ -379,6 +385,7 @@ contract("Affiliates", (accounts) => {
 		tradingFeeAmount = decodeFailed[0].args["tradingFeeTokenAmount"];
 		submittedToken = decodeFailed[0].args["token"];
 		submittedReferrer = decodeFailed[0].args["referrer"];
+		submittedTrader = decodeFailed[0].args["trader"];
 		sovBonusAmount = decodeFailed[0].args["sovBonusAmount"];
 		affiliatesFeePercentage = await sovryn.affiliateFeePercent();
 		sovBonusAmountShouldBePaid = await feeds.queryReturn(
@@ -391,6 +398,7 @@ contract("Affiliates", (accounts) => {
 		expect(sovBonusAmountShouldBePaid.toString(), "Incorrect sov bonus amount calculation").to.be.equal(sovBonusAmount);
 		expect(submittedToken).to.eql(doc.address);
 		expect(submittedReferrer).to.eql(referrer);
+		expect(submittedTrader).to.eql(trader);
 	});
 
 	it("Only the first trade users can be assigned Affiliates Referrer", async () => {

--- a/tests-js/affiliates.test.js
+++ b/tests-js/affiliates.test.js
@@ -465,7 +465,7 @@ contract("Affiliates", (accounts) => {
 
 	it("payTradingFeeToAffiliatesReferrer() Should revert if not called by protocol", async () => {
 		await expectRevert(
-			sovryn.payTradingFeeToAffiliatesReferrer(referrer, tokenSOV.address, wei("1", "gwei")),
+			sovryn.payTradingFeeToAffiliatesReferrer(referrer, trader, tokenSOV.address, wei("1", "gwei")),
 			"Affiliates: not authorized"
 		);
 	});

--- a/tests-js/affiliates_integration.test.js
+++ b/tests-js/affiliates_integration.test.js
@@ -218,6 +218,8 @@ contract("Affiliates", (accounts) => {
 		let affiliateRewardsHeld = await sovryn.affiliateRewardsHeld(referrer);
 		let submittedAffiliatesReward = decode[0].args["sovBonusAmount"];
 		let submittedTokenBonusAmount = decode[0].args["tokenBonusAmount"];
+		let submittedReferrer = decode[0].args["referrer"];
+		let submittedTrader = decode[0].args["trader"];
 		expect(isHeld, "First trade affiliates reward must be in held").to.be.true;
 		expect(referrerFee.toString(), "Token bonus rewards is not matched").to.be.equal(submittedTokenBonusAmount.toString());
 
@@ -229,6 +231,9 @@ contract("Affiliates", (accounts) => {
 		// Check lockedSOV Balance of the referrer
 		let referrerBalanceInLockedSOV = await lockedSOV.getLockedBalance(referrer);
 		expect(referrerBalanceInLockedSOV.toString(), "Referrer balance in lockedSOV is not matched").to.be.equal(new BN(0).toString());
+
+		expect(submittedReferrer).to.eql(referrer);
+		expect(submittedTrader).to.eql(trader);
 
 		// Change the min referrals to payout to 1
 		await sovryn.setMinReferralsToPayoutAffiliates(1);
@@ -258,6 +263,8 @@ contract("Affiliates", (accounts) => {
 		submittedAffiliatesReward = decode[0].args["sovBonusAmount"];
 		submittedTokenBonusAmount = decode[0].args["tokenBonusAmount"];
 		sovBonusAmountPaid = decode[0].args["sovBonusAmountPaid"];
+		submittedReferrer = decode[0].args["referrer"];
+		submittedTrader = decode[0].args["trader"];
 
 		expect(affiliateRewardsHeld.toString(), "affiliateRewardHeld should be zero at this point").to.be.equal(new BN(0).toString());
 		expect(referrerFee.toString(), "Token bonus rewards is not matched").to.be.equal(submittedTokenBonusAmount.toString());
@@ -277,6 +284,9 @@ contract("Affiliates", (accounts) => {
 		expect(referrerBalanceInLockedSOV.toString(), "Referrer balance in lockedSOV is not matched").to.be.equal(
 			checkSovBonusAmountPaid.toString()
 		);
+
+		expect(submittedReferrer).to.eql(referrer);
+		expect(submittedTrader).to.eql(trader);
 
 		// Do withdrawal
 		let referrerTokenBalance = await doc.balanceOf(referrer);


### PR DESCRIPTION
This PR is tend to add the Trader into the PayTradingToAffiliate event, so that can be used by frontend