### PR TITLE
Affiliates:Add view function to get est token rewards value in rbtc

### DIFF
--- a/contracts/interfaces/ISovryn.sol
+++ b/contracts/interfaces/ISovryn.sol
@@ -400,4 +400,6 @@ contract ISovryn is
 	function getAffiliateRewardsHeld(address referrer) external view returns (uint256);
 
 	function getAffiliateTradingTokenFeePercent() external view returns (uint256 affiliateTradingTokenFeePercent);
+
+	function getAffiliatesTokenRewardsValueInRbtc(address referrer) external view returns (uint256 rbtcTotalAmount);
 }

--- a/interfaces/ISovrynBrownie.sol
+++ b/interfaces/ISovrynBrownie.sol
@@ -379,6 +379,8 @@ contract ISovrynBrownie is
 
 	function getAffiliateTradingTokenFeePercent() external view returns (uint256 affiliateTradingTokenFeePercent);
 
+	function getAffiliatesTokenRewardsValueInRbtc(address referrer) external view returns (uint256 rbtcTotalAmount);
+
 	function swapExternal(
 		address sourceToken,
 		address destToken,


### PR DESCRIPTION
Affiliates modules will have a view function to calculate all of the token rewards that is belongs to a particular referrer in rbtc format.

In case the price feeds query is not found / error, the token assets will be ignored from the calculation