### PR TITLE
Event toggle function pause new

### DIFF
--- a/contracts/connectors/loantoken/modules/LoanTokenSettingsLowerAdmin.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenSettingsLowerAdmin.sol
@@ -22,6 +22,7 @@ contract LoanTokenSettingsLowerAdmin is LoanTokenLogicStorage {
 	/* Events */
 
 	event SetTransactionLimits(address[] addresses, uint256[] limits);
+	event ToggleFunctionPaused(string functionId, bool prevFlag, bool newFlag);
 
 	/* Functions */
 
@@ -184,6 +185,7 @@ contract LoanTokenSettingsLowerAdmin is LoanTokenLogicStorage {
 		string memory funcId, /// example: "mint(uint256,uint256)"
 		bool isPaused
 	) public {
+		bool paused;
 		require(msg.sender == pauser, "onlyPauser");
 		/// keccak256("iToken_FunctionPause")
 		bytes32 slot =
@@ -194,8 +196,13 @@ contract LoanTokenSettingsLowerAdmin is LoanTokenLogicStorage {
 				)
 			);
 		assembly {
+			paused := sload(slot)
+		}
+		require(paused != isPaused, "invalid");
+		assembly {
 			sstore(slot, isPaused)
 		}
+		emit ToggleFunctionPaused(funcId, !isPaused, isPaused);
 	}
 
 	/**

--- a/contracts/connectors/loantoken/modules/LoanTokenSettingsLowerAdmin.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenSettingsLowerAdmin.sol
@@ -22,7 +22,7 @@ contract LoanTokenSettingsLowerAdmin is LoanTokenLogicStorage {
 	/* Events */
 
 	event SetTransactionLimits(address[] addresses, uint256[] limits);
-	event ToggleFunctionPaused(string functionId, bool prevFlag, bool newFlag);
+	event ToggledFunctionPaused(string functionId, bool prevFlag, bool newFlag);
 
 	/* Functions */
 
@@ -188,21 +188,20 @@ contract LoanTokenSettingsLowerAdmin is LoanTokenLogicStorage {
 		bool paused;
 		require(msg.sender == pauser, "onlyPauser");
 		/// keccak256("iToken_FunctionPause")
-		bytes32 slot =
-			keccak256(
-				abi.encodePacked(
-					bytes4(keccak256(abi.encodePacked(funcId))),
-					uint256(0xd46a704bc285dbd6ff5ad3863506260b1df02812f4f857c8cc852317a6ac64f2)
-				)
-			);
+		bytes32 slot = keccak256(
+			abi.encodePacked(
+				bytes4(keccak256(abi.encodePacked(funcId))),
+				uint256(0xd46a704bc285dbd6ff5ad3863506260b1df02812f4f857c8cc852317a6ac64f2)
+			)
+		);
 		assembly {
 			paused := sload(slot)
 		}
-		require(paused != isPaused, "invalid");
+		require(paused != isPaused, "isPaused is already set to that value");
 		assembly {
 			sstore(slot, isPaused)
 		}
-		emit ToggleFunctionPaused(funcId, !isPaused, isPaused);
+		emit ToggledFunctionPaused(funcId, !isPaused, isPaused);
 	}
 
 	/**

--- a/contracts/connectors/loantoken/modules/LoanTokenSettingsLowerAdmin.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenSettingsLowerAdmin.sol
@@ -188,12 +188,13 @@ contract LoanTokenSettingsLowerAdmin is LoanTokenLogicStorage {
 		bool paused;
 		require(msg.sender == pauser, "onlyPauser");
 		/// keccak256("iToken_FunctionPause")
-		bytes32 slot = keccak256(
-			abi.encodePacked(
-				bytes4(keccak256(abi.encodePacked(funcId))),
-				uint256(0xd46a704bc285dbd6ff5ad3863506260b1df02812f4f857c8cc852317a6ac64f2)
-			)
-		);
+		bytes32 slot =
+			keccak256(
+				abi.encodePacked(
+					bytes4(keccak256(abi.encodePacked(funcId))),
+					uint256(0xd46a704bc285dbd6ff5ad3863506260b1df02812f4f857c8cc852317a6ac64f2)
+				)
+			);
 		assembly {
 			paused := sload(slot)
 		}

--- a/contracts/interfaces/ILoanTokenModules.sol
+++ b/contracts/interfaces/ILoanTokenModules.sol
@@ -19,6 +19,8 @@ interface ILoanTokenModules {
 
 	event SetTransactionLimits(address[] addresses, uint256[] limits);
 
+	event ToggleFunctionPaused(string functionId, bool prevFlag, bool newFlag);
+
 	/** INTERFACE */
 
 	/** START LOAN TOKEN SETTINGS LOWER ADMIN */

--- a/contracts/interfaces/ILoanTokenModules.sol
+++ b/contracts/interfaces/ILoanTokenModules.sol
@@ -19,7 +19,7 @@ interface ILoanTokenModules {
 
 	event SetTransactionLimits(address[] addresses, uint256[] limits);
 
-	event ToggleFunctionPaused(string functionId, bool prevFlag, bool newFlag);
+	event ToggledFunctionPaused(string functionId, bool prevFlag, bool newFlag);
 
 	/** INTERFACE */
 

--- a/tests/loan-token/Administration.test.js
+++ b/tests/loan-token/Administration.test.js
@@ -132,12 +132,12 @@ contract("LoanTokenAdministration", (accounts) => {
 			let localLoanToken = loanToken;
 			await localLoanToken.setPauser(accounts[0]);
 			let tx = await localLoanToken.toggleFunctionPause(functionSignature, true);
-			expectEvent(tx, "ToggleFunctionPaused", {
+			expectEvent(tx, "ToggledFunctionPaused", {
 				functionId: functionSignature,
 				prevFlag: false,
 				newFlag: true,
 			});
-			await expectRevert(localLoanToken.toggleFunctionPause(functionSignature, true), "invalid");
+			await expectRevert(localLoanToken.toggleFunctionPause(functionSignature, true), "isPaused is already set to that value");
 
 			await expectRevert(open_margin_trade_position(loanToken, RBTC, WRBTC, SUSD, accounts[1]), "unauthorized");
 
@@ -146,12 +146,12 @@ contract("LoanTokenAdministration", (accounts) => {
 
 			await localLoanToken.setPauser(accounts[0]);
 			tx = await localLoanToken.toggleFunctionPause(functionSignature, false);
-			expectEvent(tx, "ToggleFunctionPaused", {
+			expectEvent(tx, "ToggledFunctionPaused", {
 				functionId: functionSignature,
 				prevFlag: true,
 				newFlag: false,
 			});
-			await expectRevert(localLoanToken.toggleFunctionPause(functionSignature, false), "invalid");
+			await expectRevert(localLoanToken.toggleFunctionPause(functionSignature, false), "isPaused is already set to that value");
 			await open_margin_trade_position(loanToken, RBTC, WRBTC, SUSD, accounts[1]);
 
 			// check if checkPause returns false

--- a/tests/loan-token/Administration.test.js
+++ b/tests/loan-token/Administration.test.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai");
-const { expectRevert, BN } = require("@openzeppelin/test-helpers");
+const { expectRevert, BN, expectEvent } = require("@openzeppelin/test-helpers");
 const LoanToken = artifacts.require("LoanToken");
 const LoanTokenLogicBeacon = artifacts.require("LoanTokenLogicBeacon");
 const LoanTokenLogicProxy = artifacts.require("LoanTokenLogicProxy");
@@ -131,7 +131,13 @@ contract("LoanTokenAdministration", (accounts) => {
 			// pause the given function and make sure the function can't be called anymore
 			let localLoanToken = loanToken;
 			await localLoanToken.setPauser(accounts[0]);
-			await localLoanToken.toggleFunctionPause(functionSignature, true);
+			let tx = await localLoanToken.toggleFunctionPause(functionSignature, true);
+			expectEvent(tx, "ToggleFunctionPaused", {
+				functionId: functionSignature,
+				prevFlag: false,
+				newFlag: true,
+			});
+			await expectRevert(localLoanToken.toggleFunctionPause(functionSignature, true), "invalid");
 
 			await expectRevert(open_margin_trade_position(loanToken, RBTC, WRBTC, SUSD, accounts[1]), "unauthorized");
 
@@ -139,7 +145,13 @@ contract("LoanTokenAdministration", (accounts) => {
 			assert(localLoanToken.checkPause(functionSignature));
 
 			await localLoanToken.setPauser(accounts[0]);
-			await localLoanToken.toggleFunctionPause(functionSignature, false);
+			tx = await localLoanToken.toggleFunctionPause(functionSignature, false);
+			expectEvent(tx, "ToggleFunctionPaused", {
+				functionId: functionSignature,
+				prevFlag: true,
+				newFlag: false,
+			});
+			await expectRevert(localLoanToken.toggleFunctionPause(functionSignature, false), "invalid");
 			await open_margin_trade_position(loanToken, RBTC, WRBTC, SUSD, accounts[1]);
 
 			// check if checkPause returns false


### PR DESCRIPTION
closes: #297
Added an event ToggleFunctionPaused to the function toggleFunctionPause()

We earlier had Contract Size issues and hence this version is built using updated Loan Token logic using Beacon Chain. This PR is a replacement of: https://github.com/DistributedCollective/Sovryn-smart-contracts/pull/317