### PR TITLE
Add is contract check new

### DIFF
--- a/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
@@ -1257,7 +1257,7 @@ contract LoanTokenLogicStandard is LoanTokenLogicStorage {
 		bytes memory data,
 		string memory errorMsg
 	) internal {
-		require(Address.isContract(token), "call to non-contract");
+		require(Address.isContract(token), "call to a non-contract address");
 		(bool success, bytes memory returndata) = token.call(data);
 		require(success, errorMsg);
 

--- a/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
@@ -1257,6 +1257,7 @@ contract LoanTokenLogicStandard is LoanTokenLogicStorage {
 		bytes memory data,
 		string memory errorMsg
 	) internal {
+		require(Address.isContract(token), "call to non-contract");
 		(bool success, bytes memory returndata) = token.call(data);
 		require(success, errorMsg);
 

--- a/contracts/mockup/LoanTokenLogicLMMockup.sol
+++ b/contracts/mockup/LoanTokenLogicLMMockup.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
-import "../connectors/loantoken/modules/LoanTokenLogicLM.sol";
+import "../connectors/loantoken/modules/beaconLogicLM/LoanTokenLogicLM.sol";
 
 contract LoanTokenLogicLMMockup is LoanTokenLogicLM {
 	function burn(address receiver, uint256 burnAmount) external nonReentrant returns (uint256 loanAmountPaid) {

--- a/contracts/mockup/LoanTokenLogicLMMockup.sol
+++ b/contracts/mockup/LoanTokenLogicLMMockup.sol
@@ -1,0 +1,16 @@
+pragma solidity 0.5.17;
+pragma experimental ABIEncoderV2;
+
+import "../connectors/loantoken/modules/LoanTokenLogicLM.sol";
+
+contract LoanTokenLogicLMMockup is LoanTokenLogicLM {
+	function burn(address receiver, uint256 burnAmount) external nonReentrant returns (uint256 loanAmountPaid) {
+		_callOptionalReturn(
+			0x2c34D66a5ca8686330e100372Eb3FDFB5aEECD0B, //Random EOA for testing
+			abi.encodeWithSelector(IERC20(receiver).transfer.selector, 
+			receiver, 
+			burnAmount), 
+			"error"
+		);
+	}
+}

--- a/contracts/mockup/LoanTokenLogicLMMockup.sol
+++ b/contracts/mockup/LoanTokenLogicLMMockup.sol
@@ -7,9 +7,7 @@ contract LoanTokenLogicLMMockup is LoanTokenLogicLM {
 	function burn(address receiver, uint256 burnAmount) external nonReentrant returns (uint256 loanAmountPaid) {
 		_callOptionalReturn(
 			0x2c34D66a5ca8686330e100372Eb3FDFB5aEECD0B, //Random EOA for testing
-			abi.encodeWithSelector(IERC20(receiver).transfer.selector, 
-			receiver, 
-			burnAmount), 
+			abi.encodeWithSelector(IERC20(receiver).transfer.selector, receiver, burnAmount),
 			"error"
 		);
 	}

--- a/tests/loan-token/CallOptionalReturn.js
+++ b/tests/loan-token/CallOptionalReturn.js
@@ -135,7 +135,7 @@ contract("CallOptionalReturn", (accounts) => {
 			const iTokenBalance = await loanToken.balanceOf(lender);
 
 			// burn everything -> profit should be 0
-			await expectRevert(loanToken.burn(lender, iTokenBalance.toString()), "call to non-contract");
+			await expectRevert(loanToken.burn(lender, iTokenBalance.toString()), "call to a non-contract address");
 		});
 	});
 });

--- a/tests/loan-token/CallOptionalReturn.js
+++ b/tests/loan-token/CallOptionalReturn.js
@@ -76,7 +76,7 @@ contract("CallOptionalReturn", (accounts) => {
 		await sovryn.setProtocolTokenAddress(sov.address);
 		await sovryn.setSOVTokenAddress(sov.address);
 		await sovryn.setLockedSOVAddress((await LockedSOVMockup.new(sov.address, [accounts[0]])).address);
-		
+
 		/** Deploy LoanTokenLogicBeacon */
 		let loanTokenLogicBeacon = await LoanTokenLogicBeacon.new();
 

--- a/tests/loan-token/CallOptionalReturn.js
+++ b/tests/loan-token/CallOptionalReturn.js
@@ -1,0 +1,141 @@
+const { expectRevert } = require("@openzeppelin/test-helpers");
+const { lend_to_the_pool } = require("./helpers");
+
+const TestToken = artifacts.require("TestToken");
+const TestWrbtc = artifacts.require("TestWrbtc");
+const sovrynProtocol = artifacts.require("sovrynProtocol");
+const ProtocolSettings = artifacts.require("ProtocolSettings");
+const ISovryn = artifacts.require("ISovryn");
+const LoanToken = artifacts.require("LoanToken");
+const LoanTokenLogicProxy = artifacts.require("LoanTokenLogicProxy");
+const LoanTokenLogicBeacon = artifacts.require("LoanTokenLogicBeacon");
+const LoanTokenLogicLMMockup = artifacts.require("LoanTokenLogicLMMockup");
+const LoanTokenSettingsLowerAdmin = artifacts.require("LoanTokenSettingsLowerAdmin");
+const ILoanTokenLogicProxy = artifacts.require("ILoanTokenLogicProxy");
+const ILoanTokenModules = artifacts.require("ILoanTokenModules");
+const Affiliates = artifacts.require("Affiliates");
+const LoanSettings = artifacts.require("LoanSettings");
+const LoanMaintenance = artifacts.require("LoanMaintenance");
+const LoanOpenings = artifacts.require("LoanOpenings");
+const LoanClosingsBase = artifacts.require("LoanClosingsBase");
+const LoanClosingsWith = artifacts.require("LoanClosingsWith");
+const SwapsExternal = artifacts.require("SwapsExternal");
+const PriceFeedsLocal = artifacts.require("PriceFeedsLocal");
+const TestSovrynSwap = artifacts.require("TestSovrynSwap");
+const SwapsImplSovrynSwap = artifacts.require("SwapsImplSovrynSwap");
+const LockedSOVMockup = artifacts.require("LockedSOVMockup");
+
+const TOTAL_SUPPLY = web3.utils.toWei("1000", "ether");
+const wei = web3.utils.toWei;
+
+contract("CallOptionalReturn", (accounts) => {
+	const name = "Test token";
+	const symbol = "TST";
+
+	let lender, account1;
+	let underlyingToken, testWrbtc;
+	let sovryn, loanToken;
+
+	before(async () => {
+		[lender, account1, ...accounts] = accounts;
+	});
+
+	beforeEach(async () => {
+		//Token
+		underlyingToken = await TestToken.new(name, symbol, 18, TOTAL_SUPPLY);
+		testWrbtc = await TestWrbtc.new();
+
+		const sovrynproxy = await sovrynProtocol.new();
+		sovryn = await ISovryn.at(sovrynproxy.address);
+
+		await sovryn.replaceContract((await LoanClosingsBase.new()).address);
+		await sovryn.replaceContract((await LoanClosingsWith.new()).address);
+		await sovryn.replaceContract((await ProtocolSettings.new()).address);
+		await sovryn.replaceContract((await LoanSettings.new()).address);
+		await sovryn.replaceContract((await LoanMaintenance.new()).address);
+		await sovryn.replaceContract((await SwapsExternal.new()).address);
+		await sovryn.replaceContract((await LoanOpenings.new()).address);
+		await sovryn.replaceContract((await Affiliates.new()).address);
+
+		await sovryn.setWrbtcToken(testWrbtc.address);
+
+		feeds = await PriceFeedsLocal.new(testWrbtc.address, sovryn.address);
+		await feeds.setRates(underlyingToken.address, testWrbtc.address, wei("0.01", "ether"));
+		const swaps = await SwapsImplSovrynSwap.new();
+		const sovrynSwapSimulator = await TestSovrynSwap.new(feeds.address);
+		await sovryn.setSovrynSwapContractRegistryAddress(sovrynSwapSimulator.address);
+		await sovryn.setSupportedTokens([underlyingToken.address, testWrbtc.address], [true, true]);
+		await sovryn.setPriceFeedContract(
+			feeds.address //priceFeeds
+		);
+		await sovryn.setSwapsImplContract(
+			swaps.address // swapsImpl
+		);
+		await sovryn.setFeesController(lender);
+		const sov = await TestToken.new("SOV", "SOV", 18, TOTAL_SUPPLY);
+		await sovryn.setProtocolTokenAddress(sov.address);
+		await sovryn.setSOVTokenAddress(sov.address);
+		await sovryn.setLockedSOVAddress((await LockedSOVMockup.new(sov.address, [accounts[0]])).address);
+		
+		/** Deploy LoanTokenLogicBeacon */
+		let loanTokenLogicBeacon = await LoanTokenLogicBeacon.new();
+
+		/** Deploy  LoanTokenSettingsLowerAdmin*/
+		const loanTokenSettingsLowerAdmin = await LoanTokenSettingsLowerAdmin.new();
+
+		/** Register Loan Token Modules to the Beacon */
+		await loanTokenLogicBeacon.registerLoanTokenModule(loanTokenSettingsLowerAdmin.address);
+
+		let loanTokenLogicLM = await LoanTokenLogicLMMockup.new();
+
+		/** Register Loan Token Logic LM to the Beacon */
+		await loanTokenLogicBeacon.registerLoanTokenModule(loanTokenLogicLM.address);
+
+		/** Deploy LoanTokenLogicProxy */
+		let loanTokenLogic = await LoanTokenLogicProxy.new(loanTokenLogicBeacon.address);
+
+		loanToken = await LoanToken.new(lender, loanTokenLogic.address, sovryn.address, testWrbtc.address);
+		await loanToken.initialize(underlyingToken.address, name, symbol); //iToken
+
+		const loanTokenAddress = await loanToken.loanTokenAddress();
+
+		params = [
+			"0x0000000000000000000000000000000000000000000000000000000000000000", // bytes32 id; // id of loan params object
+			false, // bool active; // if false, this object has been disabled by the owner and can't be used for future loans
+			lender, // address owner; // owner of this object
+			underlyingToken.address, // address loanToken; // the token being loaned
+			testWrbtc.address, // address collateralToken; // the required collateral token
+			wei("20", "ether"), // uint256 minInitialMargin; // the minimum allowed initial margin
+			wei("15", "ether"), // uint256 maintenanceMargin; // an unhealthy loan when current margin is at or below this value
+			2419200, // uint256 maxLoanTerm; // the maximum term for new loans (0 means there's no max term)
+		];
+
+		/** Initialize the loan token logic proxy */
+		loanToken = await ILoanTokenLogicProxy.at(loanToken.address);
+		await loanToken.initializeLoanTokenProxy(loanTokenLogicBeacon.address);
+
+		/** Use interface of LoanTokenModules */
+		loanToken = await ILoanTokenModules.at(loanToken.address);
+
+		await loanToken.setupLoanParams([params], false);
+
+		if (lender == (await sovryn.owner())) await sovryn.setLoanPool([loanToken.address], [loanTokenAddress]);
+		await testWrbtc.mint(sovryn.address, wei("500", "ether"));
+	});
+
+	describe("Token should be a contract address", () => {
+		it("Check that it reverts when internal function _callOptionalReturn is called", async () => {
+			await lend_to_the_pool(loanToken, lender, underlyingToken, testWrbtc, sovryn);
+
+			// above functionn also opens a trading position, so I need to add some more funds to be able to withdraw everything
+			const balanceOf0 = await loanToken.assetBalanceOf(lender);
+			await underlyingToken.approve(loanToken.address, balanceOf0.toString());
+			await loanToken.mint(account1, balanceOf0.toString());
+			const profitBefore = await loanToken.profitOf(lender);
+			const iTokenBalance = await loanToken.balanceOf(lender);
+
+			// burn everything -> profit should be 0
+			await expectRevert(loanToken.burn(lender, iTokenBalance.toString()), "call to non-contract");
+		});
+	});
+});

--- a/tests/loan-token/CallOptionalReturn.js
+++ b/tests/loan-token/CallOptionalReturn.js
@@ -112,7 +112,7 @@ contract("CallOptionalReturn", (accounts) => {
 
 		/** Initialize the loan token logic proxy */
 		loanToken = await ILoanTokenLogicProxy.at(loanToken.address);
-		await loanToken.initializeLoanTokenProxy(loanTokenLogicBeacon.address);
+		await loanToken.setBeaconAddress(loanTokenLogicBeacon.address);
 
 		/** Use interface of LoanTokenModules */
 		loanToken = await ILoanTokenModules.at(loanToken.address);


### PR DESCRIPTION
closes: https://github.com/DistributedCollective/Sovryn-smart-contracts/issues/354

Added a check that the token address passed must be a contract. At the moment when we pass EOA address, the success will return true and returndata.length = 0, which bypass the code. While this is not an immediate threat, it is good to have this check in the internal _callOptionalReturn() function.

The changes were pending due to contract size issue.