### PR TITLE
Reverse funds iwrbtc

### DIFF
--- a/contracts/connectors/loantoken/modules/LoanTokenLogicLM.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicLM.sol
@@ -17,7 +17,7 @@ contract LoanTokenLogicLM is LoanTokenLogicStandard {
 	 * @return The list of function signatures (bytes4[])
 	 */
 	function getListFunctionSignatures() external pure returns (bytes4[] memory functionSignatures, bytes32 moduleName) {
-		bytes4[] memory res = new bytes4[](35);
+		bytes4[] memory res = new bytes4[](36);
 
 		// Loan Token Logic Standard
 		res[0] = bytes4(keccak256("mint(address,uint256)"));
@@ -68,6 +68,7 @@ contract LoanTokenLogicLM is LoanTokenLogicStandard {
 
 		// Loan Token Logic Storage Additional Variable
 		res[34] = bytes4(keccak256("liquidityMiningAddress()"));
+		res[35] = this.withdrawRBTCTo.selector;
 
 		return (res, stringToBytes32("LoanTokenLogicLM"));
 	}

--- a/contracts/connectors/loantoken/modules/LoanTokenLogicLM.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicLM.sol
@@ -79,7 +79,7 @@ contract LoanTokenLogicLM is LoanTokenLogicStandard {
 
 		// Loan Token Logic Storage Additional Variable
 		res[33] = bytes4(keccak256("liquidityMiningAddress()"));
-		res[34] = this.withdrawAllRBTC.selector;
+		res[34] = this.withdrawRBTCTo.selector;
 
 		return (res, stringToBytes32("LoanTokenLogicLM"));
 	}

--- a/contracts/connectors/loantoken/modules/LoanTokenLogicLM.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicLM.sol
@@ -29,7 +29,7 @@ contract LoanTokenLogicLM is LoanTokenLogicStandard {
 	 * @return The list of function signatures (bytes4[])
 	 */
 	function getListFunctionSignatures() external pure returns (bytes4[] memory functionSignatures, bytes32 moduleName) {
-		bytes4[] memory res = new bytes4[](34);
+		bytes4[] memory res = new bytes4[](35);
 
 		// Loan Token Logic Standard
 		res[0] = bytes4(keccak256("mint(address,uint256)"));
@@ -79,6 +79,7 @@ contract LoanTokenLogicLM is LoanTokenLogicStandard {
 
 		// Loan Token Logic Storage Additional Variable
 		res[33] = bytes4(keccak256("liquidityMiningAddress()"));
+		res[34] = this.withdrawAllRBTC.selector;
 
 		return (res, stringToBytes32("LoanTokenLogicLM"));
 	}

--- a/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
@@ -430,10 +430,10 @@ contract LoanTokenLogicStandard is LoanTokenLogicStorage {
 	 * @param _amount The amount of rBTC to be transferred.
 	 */
 	function withdrawRBTCTo(address payable _receiverAddress, uint256 _amount) external onlyOwner {
-        require(_receiverAddress != address(0), "receiver address invalid");
-        require(_amount > 0, "non-zero withdraw amount expected");    
-        require(_amount <= address(this).balance, "withdraw amount cannot exceed balance");
-        _receiverAddress.transfer(_amount);
+		require(_receiverAddress != address(0), "receiver address invalid");
+		require(_amount > 0, "non-zero withdraw amount expected");
+		require(_amount <= address(this).balance, "withdraw amount cannot exceed balance");
+		_receiverAddress.transfer(_amount);
 	}
 
 	/**

--- a/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
@@ -813,12 +813,12 @@ contract LoanTokenLogicStandard is LoanTokenLogicStorage {
 				return
 					ProtocolLike(sovrynContractAddress)
 						.getRequiredCollateral(
-							loanTokenAddress,
-							collateralTokenAddress != address(0) ? collateralTokenAddress : wrbtcTokenAddress,
-							newBorrowAmount,
-							50 * 10**18, /// initialMargin
-							true /// isTorqueLoan
-						)
+						loanTokenAddress,
+						collateralTokenAddress != address(0) ? collateralTokenAddress : wrbtcTokenAddress,
+						newBorrowAmount,
+						50 * 10**18, /// initialMargin
+						true /// isTorqueLoan
+					)
 						.add(10); /// Some dust to compensate for rounding errors.
 			}
 		}
@@ -869,12 +869,8 @@ contract LoanTokenLogicStandard is LoanTokenLogicStorage {
 		address collateralTokenAddress,
 		uint256 minReturn
 	) public view {
-		(, uint256 estimatedCollateral, ) = getEstimatedMarginDetails(
-			leverageAmount,
-			loanTokenSent,
-			collateralTokenSent,
-			collateralTokenAddress
-		);
+		(, uint256 estimatedCollateral, ) =
+			getEstimatedMarginDetails(leverageAmount, loanTokenSent, collateralTokenSent, collateralTokenAddress);
 		require(estimatedCollateral >= minReturn, "coll too low");
 	}
 
@@ -1002,19 +998,16 @@ contract LoanTokenLogicStandard is LoanTokenLogicStorage {
 
 		if (collateralTokenSent != 0) {
 			/// @dev Get the oracle rate from collateral -> loan
-			(uint256 collateralToLoanRate, uint256 collateralToLoanPrecision) = FeedsLike(ProtocolLike(sovrynContractAddress).priceFeeds())
-				.queryRate(collateralTokenAddress, loanTokenAddress);
+			(uint256 collateralToLoanRate, uint256 collateralToLoanPrecision) =
+				FeedsLike(ProtocolLike(sovrynContractAddress).priceFeeds()).queryRate(collateralTokenAddress, loanTokenAddress);
 			require((collateralToLoanRate != 0) && (collateralToLoanPrecision != 0), "invalid rate collateral token");
 
 			/// @dev Compute the loan token amount with the oracle rate.
 			uint256 loanTokenAmount = collateralTokenSent.mul(collateralToLoanRate).div(collateralToLoanPrecision);
 
 			/// @dev See how many collateralTokens we would get if exchanging this amount of loan tokens to collateral tokens.
-			uint256 collateralTokenAmount = ProtocolLike(sovrynContractAddress).getSwapExpectedReturn(
-				loanTokenAddress,
-				collateralTokenAddress,
-				loanTokenAmount
-			);
+			uint256 collateralTokenAmount =
+				ProtocolLike(sovrynContractAddress).getSwapExpectedReturn(loanTokenAddress, collateralTokenAddress, loanTokenAmount);
 
 			/// @dev Probably not the same due to the price difference.
 			if (collateralTokenAmount != collateralTokenSent) {

--- a/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
@@ -425,15 +425,15 @@ contract LoanTokenLogicStandard is LoanTokenLogicStorage {
 	}
 
 	/**
-	 * @notice Withdraws all RBTC from the contract by Multisig.
+	 * @notice Withdraws RBTC from the contract by Multisig.
 	 * @param _receiverAddress The address where the rBTC has to be transferred.
+	 * @param _amount The amount of rBTC to be transferred.
 	 */
-	function withdrawAllRBTC(address payable _receiverAddress) external onlyOwner {
-		require(_receiverAddress != address(0), "receiver address invalid");
-		uint256 value = address(this).balance;
-		if (value != 0) {
-			_receiverAddress.transfer(value);
-		}
+	function withdrawRBTCTo(address payable _receiverAddress, uint256 _amount) external onlyOwner {
+        require(_receiverAddress != address(0), "receiver address invalid");
+        require(_amount > 0, "non-zero withdraw amount expected");    
+        require(_amount <= address(this).balance, "withdraw amount cannot exceed balance");
+        _receiverAddress.transfer(_amount);
 	}
 
 	/**

--- a/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
@@ -425,6 +425,19 @@ contract LoanTokenLogicStandard is LoanTokenLogicStorage {
 	}
 
 	/**
+	 * @notice Withdraws all RBTC from the contract by Multisig.
+	 * @param _receiverAddress The address where the rBTC has to be transferred.
+	 */
+	function withdrawAllRBTC(address payable _receiverAddress) external onlyOwner {
+		require(_receiverAddress != address(0), "receiver address invalid");
+		uint256 value = address(this).balance;
+		if (value != 0) {
+			_receiverAddress.transfer(value);
+		}
+	}
+
+
+	/**
 	 * @notice Transfer tokens wrapper.
 	 * Sets token owner the msg.sender.
 	 * Sets maximun allowance uint256(-1) to ensure tokens are always transferred.

--- a/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicStandard.sol
@@ -436,7 +436,6 @@ contract LoanTokenLogicStandard is LoanTokenLogicStorage {
 		}
 	}
 
-
 	/**
 	 * @notice Transfer tokens wrapper.
 	 * Sets token owner the msg.sender.

--- a/contracts/connectors/loantoken/modules/LoanTokenLogicWrbtc.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicWrbtc.sol
@@ -22,7 +22,7 @@ contract LoanTokenLogicWrbtc is LoanTokenLogicStandard {
 	 * @return The list of function signatures (bytes4[])
 	 */
 	function getListFunctionSignatures() external pure returns (bytes4[] memory functionSignatures, bytes32 moduleName) {
-		bytes4[] memory res = new bytes4[](35);
+		bytes4[] memory res = new bytes4[](36);
 
 		// Loan Token Logic Standard
 		res[0] = this.mint.selector;
@@ -68,6 +68,7 @@ contract LoanTokenLogicWrbtc is LoanTokenLogicStandard {
 
 		// Loan Token Logic Storage Additional Variable
 		res[34] = bytes4(keccak256("liquidityMiningAddress()"));
+		res[35] = this.withdrawRBTCTo.selector;
 
 		return (res, stringToBytes32("LoanTokenLogicWrbtc"));
 	}

--- a/contracts/connectors/loantoken/modules/LoanTokenLogicWrbtc.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicWrbtc.sol
@@ -67,7 +67,7 @@ contract LoanTokenLogicWrbtc is LoanTokenLogicStandard {
 
 		// Loan Token Logic Storage Additional Variable
 		res[33] = bytes4(keccak256("liquidityMiningAddress()"));
-		res[34] = this.withdrawAllRBTC.selector;
+		res[34] = this.withdrawRBTCTo.selector;
 
 		return (res, stringToBytes32("LoanTokenLogicWrbtc"));
 	}

--- a/contracts/connectors/loantoken/modules/LoanTokenLogicWrbtc.sol
+++ b/contracts/connectors/loantoken/modules/LoanTokenLogicWrbtc.sol
@@ -22,7 +22,7 @@ contract LoanTokenLogicWrbtc is LoanTokenLogicStandard {
 	 * @return The list of function signatures (bytes4[])
 	 */
 	function getListFunctionSignatures() external pure returns (bytes4[] memory functionSignatures, bytes32 moduleName) {
-		bytes4[] memory res = new bytes4[](34);
+		bytes4[] memory res = new bytes4[](35);
 
 		// Loan Token Logic Standard
 		res[0] = this.mint.selector;
@@ -67,6 +67,7 @@ contract LoanTokenLogicWrbtc is LoanTokenLogicStandard {
 
 		// Loan Token Logic Storage Additional Variable
 		res[33] = bytes4(keccak256("liquidityMiningAddress()"));
+		res[34] = this.withdrawAllRBTC.selector;
 
 		return (res, stringToBytes32("LoanTokenLogicWrbtc"));
 	}

--- a/contracts/interfaces/ILoanTokenModules.sol
+++ b/contracts/interfaces/ILoanTokenModules.sol
@@ -19,6 +19,8 @@ interface ILoanTokenModules {
 
 	event SetTransactionLimits(address[] addresses, uint256[] limits);
 
+	event WithdrawRBTCTo(address indexed to, uint256 amount);
+
 	/** INTERFACE */
 
 	/** START LOAN TOKEN SETTINGS LOWER ADMIN */

--- a/contracts/interfaces/ILoanTokenModules.sol
+++ b/contracts/interfaces/ILoanTokenModules.sol
@@ -182,6 +182,8 @@ interface ILoanTokenModules {
 
 	function getMarginBorrowAmountAndRate(uint256 leverageAmount, uint256 depositAmount) external view returns (uint256, uint256);
 
+	function withdrawAllRBTC(address _receiverAddress) external;
+
 	/** START LOAN TOKEN BASE */
 	function initialPrice() external view returns (uint256);
 

--- a/contracts/interfaces/ILoanTokenModules.sol
+++ b/contracts/interfaces/ILoanTokenModules.sol
@@ -182,7 +182,7 @@ interface ILoanTokenModules {
 
 	function getMarginBorrowAmountAndRate(uint256 leverageAmount, uint256 depositAmount) external view returns (uint256, uint256);
 
-	function withdrawAllRBTC(address _receiverAddress) external;
+	function withdrawRBTCTo(address payable _receiverAddress, uint256 _amount) external;
 
 	/** START LOAN TOKEN BASE */
 	function initialPrice() external view returns (uint256);

--- a/tests/loan-token/LendingTestToken.test.js
+++ b/tests/loan-token/LendingTestToken.test.js
@@ -207,17 +207,27 @@ contract("LoanTokenLending", (accounts) => {
 			await web3.eth.sendTransaction({ from: accounts[0].toString(), to: loanToken.address, value: 10000, gas: 22000 });
 			const contractBalance = await web3.eth.getBalance(loanToken.address);
 			const balanceBefore = await web3.eth.getBalance(account4);
-			await loanToken.withdrawAllRBTC(account4);
+			await loanToken.withdrawRBTCTo(account4, contractBalance);
 			const balanceAfter = await web3.eth.getBalance(account4);
 			expect(new BN(balanceAfter).sub(new BN(balanceBefore))).to.be.a.bignumber.equal(new BN(contractBalance));
 		});
 
 		it("shouldn't withdraw when zero address is passed", async () => {
-			await expectRevert(loanToken.withdrawAllRBTC(constants.ZERO_ADDRESS), "receiver address invalid");
+			await expectRevert(loanToken.withdrawRBTCTo(constants.ZERO_ADDRESS, 100), "receiver address invalid");
 		});
 
 		it("shouldn't withdraw when triggered by anyone other than owner", async () => {
-			await expectRevert(loanToken.withdrawAllRBTC(account4, { from: account4 }), "unauthorized");
+			await expectRevert(loanToken.withdrawRBTCTo(account4, 100, { from: account4 }), "unauthorized");
+		});
+
+		it("shouldn't withdraw if amount is 0", async () => {
+			await web3.eth.sendTransaction({ from: accounts[0].toString(), to: loanToken.address, value: 10000, gas: 22000 });
+			await expectRevert(loanToken.withdrawRBTCTo(account4, 0), "non-zero withdraw amount expected");
+		});
+
+		it("shouldn't withdraw if amount is invalid", async () => {
+			await web3.eth.sendTransaction({ from: accounts[0].toString(), to: loanToken.address, value: 10000, gas: 22000 });
+			await expectRevert(loanToken.withdrawRBTCTo(account4, 20000), "withdraw amount cannot exceed balance");
 		});
 	});
 });

--- a/tests/loan-token/LendingTestToken.test.js
+++ b/tests/loan-token/LendingTestToken.test.js
@@ -217,7 +217,7 @@ contract("LoanTokenLending", (accounts) => {
 		});
 
 		it("shouldn't withdraw when triggered by anyone other than owner", async () => {
-			await expectRevert(loanToken.withdrawAllRBTC(account4, {from: account4}), "unauthorized");
+			await expectRevert(loanToken.withdrawAllRBTC(account4, { from: account4 }), "unauthorized");
 		});
 	});
 });

--- a/tests/loan-token/LendingTestToken.test.js
+++ b/tests/loan-token/LendingTestToken.test.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai");
-const { expectRevert, BN, constants } = require("@openzeppelin/test-helpers");
+const { expectRevert, expectEvent, BN, constants } = require("@openzeppelin/test-helpers");
 const { increaseTime } = require("../Utils/Ethereum");
 
 const TestToken = artifacts.require("TestToken");
@@ -207,7 +207,11 @@ contract("LoanTokenLending", (accounts) => {
 			await web3.eth.sendTransaction({ from: accounts[0].toString(), to: loanToken.address, value: 10000, gas: 22000 });
 			const contractBalance = await web3.eth.getBalance(loanToken.address);
 			const balanceBefore = await web3.eth.getBalance(account4);
-			await loanToken.withdrawRBTCTo(account4, contractBalance);
+			let tx = await loanToken.withdrawRBTCTo(account4, contractBalance);
+			expectEvent(tx, "WithdrawRBTCTo", {
+				to: account4,
+				amount: contractBalance,
+			});
 			const balanceAfter = await web3.eth.getBalance(account4);
 			expect(new BN(balanceAfter).sub(new BN(balanceBefore))).to.be.a.bignumber.equal(new BN(contractBalance));
 		});

--- a/tests/loan-token/LendingTestToken.test.js
+++ b/tests/loan-token/LendingTestToken.test.js
@@ -123,7 +123,6 @@ contract("LoanTokenLending", (accounts) => {
 		// await loanToken.setDemandCurve(baseRate, rateMultiplier, baseRate, rateMultiplier, targetLevel, kinkLevel, maxScaleRate);
 
 		await testWrbtc.mint(sovryn.address, wei("500", "ether"));
-		console.log("after before each in JS");
 	});
 
 	describe("Test lending using TestToken", () => {
@@ -200,6 +199,25 @@ contract("LoanTokenLending", (accounts) => {
 				wei("0.01", "ether"),
 				"0x"
 			);
+		});
+	});
+
+	describe("Test iRBTC withdrawal from LoanToken Contracts", () => {
+		it("test withdrawal from LoanToken contract", async () => {
+			await web3.eth.sendTransaction({ from: accounts[0].toString(), to: loanToken.address, value: 10000, gas: 22000 });
+			const contractBalance = await web3.eth.getBalance(loanToken.address);
+			const balanceBefore = await web3.eth.getBalance(account4);
+			await loanToken.withdrawAllRBTC(account4);
+			const balanceAfter = await web3.eth.getBalance(account4);
+			expect(new BN(balanceAfter).sub(new BN(balanceBefore))).to.be.a.bignumber.equal(new BN(contractBalance));
+		});
+
+		it("shouldn't withdraw when zero address is passed", async () => {
+			await expectRevert(loanToken.withdrawAllRBTC(constants.ZERO_ADDRESS), "receiver address invalid");
+		});
+
+		it("shouldn't withdraw when triggered by anyone other than owner", async () => {
+			await expectRevert(loanToken.withdrawAllRBTC(account4, {from: account4}), "unauthorized");
 		});
 	});
 });

--- a/tests/loan-token/LendingwRBTCloan.test.js
+++ b/tests/loan-token/LendingwRBTCloan.test.js
@@ -184,17 +184,27 @@ contract("LoanTokenLending", (accounts) => {
 			await loanToken.mintWithBTC(lender, false, { value: 10000, gas: 22000 });
 			const contractBalance = await web3.eth.getBalance(loanToken.address);
 			const balanceBefore = await web3.eth.getBalance(account1);
-			await loanToken.withdrawAllRBTC(account1);
+			await loanToken.withdrawRBTCTo(account1, contractBalance);
 			const balanceAfter = await web3.eth.getBalance(account1);
 			expect(new BN(balanceAfter).sub(new BN(balanceBefore))).to.be.a.bignumber.equal(new BN(contractBalance));
 		});
 
 		it("shouldn't withdraw when zero address is passed", async () => {
-			await expectRevert(loanToken.withdrawAllRBTC(constants.ZERO_ADDRESS), "receiver address invalid");
+			await expectRevert(loanToken.withdrawRBTCTo(constants.ZERO_ADDRESS, 100), "receiver address invalid");
 		});
 
 		it("shouldn't withdraw when triggered by anyone other than owner", async () => {
-			await expectRevert(loanToken.withdrawAllRBTC(account4, { from: account4 }), "unauthorized");
+			await expectRevert(loanToken.withdrawRBTCTo(account4, 100, { from: account4 }), "unauthorized");
+		});
+
+		it("shouldn't withdraw if amount is 0", async () => {
+			await web3.eth.sendTransaction({ from: accounts[0].toString(), to: loanToken.address, value: 10000, gas: 22000 });
+			await expectRevert(loanToken.withdrawRBTCTo(account4, 0), "non-zero withdraw amount expected");
+		});
+
+		it("shouldn't withdraw if amount is invalid", async () => {
+			await web3.eth.sendTransaction({ from: accounts[0].toString(), to: loanToken.address, value: 10000, gas: 22000 });
+			await expectRevert(loanToken.withdrawRBTCTo(account4, 20000), "withdraw amount cannot exceed balance");
 		});
 	});
 });

--- a/tests/loan-token/LendingwRBTCloan.test.js
+++ b/tests/loan-token/LendingwRBTCloan.test.js
@@ -180,7 +180,7 @@ contract("LoanTokenLending", (accounts) => {
 	});
 
 	describe("Test iRBTC withdrawal from RBTC loan token contract", () => {
-		it("test withdrawal from iRBTC contract", async () => {;
+		it("test withdrawal from iRBTC contract", async () => {
 			await loanToken.mintWithBTC(lender, false, { value: 10000, gas: 22000 });
 			const contractBalance = await web3.eth.getBalance(loanToken.address);
 			const balanceBefore = await web3.eth.getBalance(account1);
@@ -194,7 +194,7 @@ contract("LoanTokenLending", (accounts) => {
 		});
 
 		it("shouldn't withdraw when triggered by anyone other than owner", async () => {
-			await expectRevert(loanToken.withdrawAllRBTC(account4, {from: account4}), "unauthorized");
+			await expectRevert(loanToken.withdrawAllRBTC(account4, { from: account4 }), "unauthorized");
 		});
 	});
 });

--- a/tests/loan-token/LendingwRBTCloan.test.js
+++ b/tests/loan-token/LendingwRBTCloan.test.js
@@ -127,6 +127,7 @@ contract("LoanTokenLending", (accounts) => {
 
 		await testWrbtc.mint(sovryn.address, wei("500", "ether"));
 	});
+
 	describe("test lending using wRBTC as loanToken", () => {
 		it("test lend to the pool", async () => {
 			const baseRate = wei("1", "ether");
@@ -175,6 +176,25 @@ contract("LoanTokenLending", (accounts) => {
 			await expectRevert(loanToken.burnToBTC(lender, total_deposit_amount.mul(new BN(2)).toString(), false), "32");
 			await loanToken.burnToBTC(lender, constants.MAX_UINT256, false);
 			expect(await loanToken.balanceOf(lender)).to.be.a.bignumber.equal(new BN(0));
+		});
+	});
+
+	describe("Test iRBTC withdrawal from RBTC loan token contract", () => {
+		it("test withdrawal from iRBTC contract", async () => {;
+			await loanToken.mintWithBTC(lender, false, { value: 10000, gas: 22000 });
+			const contractBalance = await web3.eth.getBalance(loanToken.address);
+			const balanceBefore = await web3.eth.getBalance(account1);
+			await loanToken.withdrawAllRBTC(account1);
+			const balanceAfter = await web3.eth.getBalance(account1);
+			expect(new BN(balanceAfter).sub(new BN(balanceBefore))).to.be.a.bignumber.equal(new BN(contractBalance));
+		});
+
+		it("shouldn't withdraw when zero address is passed", async () => {
+			await expectRevert(loanToken.withdrawAllRBTC(constants.ZERO_ADDRESS), "receiver address invalid");
+		});
+
+		it("shouldn't withdraw when triggered by anyone other than owner", async () => {
+			await expectRevert(loanToken.withdrawAllRBTC(account4, {from: account4}), "unauthorized");
 		});
 	});
 });

--- a/tests/loan-token/LendingwRBTCloan.test.js
+++ b/tests/loan-token/LendingwRBTCloan.test.js
@@ -184,7 +184,11 @@ contract("LoanTokenLending", (accounts) => {
 			await loanToken.mintWithBTC(lender, false, { value: 10000, gas: 22000 });
 			const contractBalance = await web3.eth.getBalance(loanToken.address);
 			const balanceBefore = await web3.eth.getBalance(account1);
-			await loanToken.withdrawRBTCTo(account1, contractBalance);
+			let tx = await loanToken.withdrawRBTCTo(account1, contractBalance);
+			expectEvent(tx, "WithdrawRBTCTo", {
+				to: account1,
+				amount: contractBalance,
+			});
 			const balanceAfter = await web3.eth.getBalance(account1);
 			expect(new BN(balanceAfter).sub(new BN(balanceBefore))).to.be.a.bignumber.equal(new BN(contractBalance));
 		});


### PR DESCRIPTION
Task: https://taiga.sovryn.app/project/sovryn-order/us/4?kanban-status=36

Owner can now withdraw all rBTC stuck in Loan Token contracts using a new function withdrawAllRBTC().

Background: When someone is interacting with the loan token contracts using a wrong ABI sending RBTC, the RBTC can get stuck on the contract. When used as intended, the loan token contracts never hold any RBTC, because all RBTC are immediately wrapped to RBTC. So, if the contract is holding RBTC, they ended up there by mistake and should hence be recoverable.