### PR TITLE
Fix potential SOV clash between trading rebate reward & fees held

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-            
+
       - name: Installing Packages
         run: npm ci
       - name: Checking Formatting

--- a/contracts/interfaces/ISovryn.sol
+++ b/contracts/interfaces/ISovryn.sol
@@ -416,4 +416,6 @@ contract ISovryn is
 	function setTradingRebateRewardsBasisPoint(uint256 newBasisPoint) external;
 
 	function getTradingRebateRewardsBasisPoint() external view returns (uint256);
+
+	function getDedicatedSOVRebate() external view returns (uint256);
 }

--- a/contracts/mockup/ProtocolSettingsMockup.sol
+++ b/contracts/mockup/ProtocolSettingsMockup.sol
@@ -62,5 +62,6 @@ contract ProtocolSettingsMockup is ProtocolSettings {
 
 		_setTarget(this.setTradingRebateRewardsBasisPoint.selector, target);
 		_setTarget(this.getTradingRebateRewardsBasisPoint.selector, target);
+		_setTarget(this.getDedicatedSOVRebate.selector, target);
 	}
 }

--- a/contracts/modules/ProtocolSettings.sol
+++ b/contracts/modules/ProtocolSettings.sol
@@ -88,6 +88,7 @@ contract ProtocolSettings is State, ProtocolTokenUser, ProtocolSettingsEvents, M
 		_setTarget(this.getSwapExternalFeePercent.selector, target);
 		_setTarget(this.setTradingRebateRewardsBasisPoint.selector, target);
 		_setTarget(this.getTradingRebateRewardsBasisPoint.selector, target);
+		_setTarget(this.getDedicatedSOVRebate.selector, target);
 		emit ProtocolModuleContractReplaced(prevModuleContractAddress, target, "ProtocolSettings");
 	}
 
@@ -721,5 +722,19 @@ contract ProtocolSettings is State, ProtocolTokenUser, ProtocolSettingsEvents, M
 	 */
 	function getTradingRebateRewardsBasisPoint() external view returns (uint256) {
 		return tradingRebateRewardsBasisPoint;
+	}
+
+	/**
+	 * @dev Get how much SOV that is dedicated to pay the trading rebate rewards.
+	 * @notice If SOV balance is less than the fees held, it will return 0.
+	 *
+	 * @return total dedicated SOV.
+	 */
+	function getDedicatedSOVRebate() public view returns (uint256) {
+		uint256 sovProtocolBalance = IERC20(sovTokenAddress).balanceOf(address(this));
+		uint256 sovFees =
+			lendingFeeTokensHeld[sovTokenAddress].add(tradingFeeTokensHeld[sovTokenAddress]).add(borrowingFeeTokensHeld[sovTokenAddress]);
+
+		return sovProtocolBalance >= sovFees ? sovProtocolBalance.sub(sovFees) : 0;
 	}
 }

--- a/interfaces/ISovrynBrownie.sol
+++ b/interfaces/ISovrynBrownie.sol
@@ -418,4 +418,6 @@ contract ISovrynBrownie is
 	function setTradingRebateRewardsBasisPoint(uint256 newBasisPoint) external;
 
 	function getTradingRebateRewardsBasisPoint() external view returns (uint256);
+
+	function getDedicatedSOVRebate() external view returns (uint256);
 }

--- a/tests/Utils/initializer.js
+++ b/tests/Utils/initializer.js
@@ -62,6 +62,7 @@ const getBZRX = async () => {
 
 const getSOV = async (sovryn, priceFeeds, SUSD, accounts) => {
 	const sov = await TestToken.new("SOV", "SOV", 18, totalSupply);
+	await sovryn.setSovrynProtocolAddress(sovryn.address);
 	await sovryn.setProtocolTokenAddress(sov.address);
 	await sovryn.setSOVTokenAddress(sov.address);
 	await sovryn.setLockedSOVAddress((await LockedSOVMockup.new(sov.address, [accounts[0]])).address);

--- a/tests/loan-token/LendingTestToken.test.js
+++ b/tests/loan-token/LendingTestToken.test.js
@@ -78,6 +78,7 @@ contract("LoanTokenLending", (accounts) => {
 		);
 		await sovryn.setFeesController(lender);
 		const sov = await TestToken.new("SOV", "SOV", 18, TOTAL_SUPPLY);
+		await sovryn.setSovrynProtocolAddress(sovryn.address);
 		await sovryn.setProtocolTokenAddress(sov.address);
 		await sovryn.setSOVTokenAddress(sov.address);
 		await sovryn.setLockedSOVAddress((await LockedSOVMockup.new(sov.address, [accounts[0]])).address);

--- a/tests/loan-token/LendingwRBTCCollateral.test.js
+++ b/tests/loan-token/LendingwRBTCCollateral.test.js
@@ -78,6 +78,7 @@ contract("LoanTokenLending", (accounts) => {
 
 		tokenSOV = await SOV.new(TOTAL_SUPPLY);
 		await sovryn.setLockedSOVAddress((await LockedSOVMockup.new(tokenSOV.address, [lender])).address);
+		await sovryn.setSovrynProtocolAddress(sovryn.address);
 		await sovryn.setProtocolTokenAddress(tokenSOV.address);
 		await sovryn.setSOVTokenAddress(tokenSOV.address);
 

--- a/tests/loan-token/LendingwRBTCloan.test.js
+++ b/tests/loan-token/LendingwRBTCloan.test.js
@@ -88,6 +88,7 @@ contract("LoanTokenLending", (accounts) => {
 
 		tokenSOV = await SOV.new(TOTAL_SUPPLY);
 		await sovryn.setLockedSOVAddress((await LockedSOVMockup.new(tokenSOV.address, [lender])).address);
+		await sovryn.setSovrynProtocolAddress(sovryn.address);
 		await sovryn.setProtocolTokenAddress(tokenSOV.address);
 		await sovryn.setSOVTokenAddress(tokenSOV.address);
 

--- a/tests/loan-token/helpers.js
+++ b/tests/loan-token/helpers.js
@@ -203,6 +203,15 @@ const cash_out_from_the_pool_uint256_max_should_withdraw_total_balance = async (
 	expect(await underlyingToken.balanceOf(lender)).to.be.a.bignumber.equal(initial_balance);
 };
 
+const set_fee_tokens_held = async (sovryn, underlyingToken, lendingFee, tradingFee, borrowingFee) => {
+	let totalFeeAmount = lendingFee.add(tradingFee).add(borrowingFee);
+	await underlyingToken.transfer(sovryn.address, totalFeeAmount);
+	await sovryn.setLendingFeeTokensHeld(underlyingToken.address, lendingFee);
+	await sovryn.setTradingFeeTokensHeld(underlyingToken.address, tradingFee);
+	await sovryn.setBorrowingFeeTokensHeld(underlyingToken.address, borrowingFee);
+	return totalFeeAmount;
+};
+
 module.exports = {
 	verify_start_conditions,
 	get_itoken_price,
@@ -213,4 +222,5 @@ module.exports = {
 	cash_out_from_the_pool,
 	//cash_out_from_the_pool_more_of_lender_balance_should_not_fail,
 	cash_out_from_the_pool_uint256_max_should_withdraw_total_balance,
+	set_fee_tokens_held,
 };

--- a/tests/protocol/ChangeLoanDurationTestToken.test.js
+++ b/tests/protocol/ChangeLoanDurationTestToken.test.js
@@ -681,6 +681,56 @@ contract("ProtocolChangeLoanDuration", (accounts) => {
 			expect(args["basisPoint"] == 0).to.be.true;
 		});
 
+		it("EarnRewardFailed should be fired if protocol does not have enough dedicated SOV to pay the rebate rewards", async () => {
+			const basisPoint = 9000;
+			// prepare the test
+			await set_demand_curve(loanToken);
+			await lend_to_pool(loanToken, SUSD, owner);
+			await sovryn.setSpecialRebates(SUSD.address, RBTC.address, wei("200", "ether"));
+			await sovryn.setTradingRebateRewardsBasisPoint(basisPoint);
+			await sovryn.withdrawProtocolToken(accounts[0], new BN(10).pow(new BN(20)));
+			const [loan_id, borrower] = await borrow_indefinite_loan(
+				loanToken,
+				sovryn,
+				SUSD,
+				RBTC,
+				accounts,
+				(withdraw_amount = new BN(10).mul(oneEth).toString()),
+				(margin = new BN(50).mul(oneEth).toString()),
+				(duration_in_seconds = 60 * 60 * 24 * 20)
+			);
+
+			const initial_loan_interest_data = await sovryn.getLoanInterestData(loan_id);
+
+			const days_to_extend = new BN(10);
+			const owed_per_day = initial_loan_interest_data["interestOwedPerDay"];
+			const deposit_amount = owed_per_day.mul(days_to_extend);
+
+			await increaseTime(10 * 24 * 60 * 60);
+			lockedSOV = await LockedSOVMockup.at(await sovryn.lockedSOVAddress());
+			const borrower_initial_balance_before_extend = (await SOV.balanceOf(borrower)).add(await lockedSOV.getLockedBalance(borrower));
+			const borrower_initial_unlock_balance_before_extend = (await SOV.balanceOf(borrower)).add(
+				await lockedSOV.getUnlockedBalance(borrower)
+			);
+
+			const loanMaintenance = await LoanMaintenance.at(sovryn.address);
+			const { receipt } = await loanMaintenance.extendLoanDuration(loan_id, deposit_amount, true, "0x", { from: borrower });
+
+			const feeRebatePercent = await sovryn.specialRebates(SUSD.address, RBTC.address);
+			const decode = decodeLogs(receipt.rawLogs, FeesEvents, "EarnRewardFail");
+			const args = decode[0].args;
+			expect(args["receiver"] == borrower).to.be.true;
+			expect(args["token"] == SOV.address).to.be.true;
+			expect(args["loanId"] == loan_id).to.be.true;
+			expect(args["feeRebatePercent"] == feeRebatePercent).to.be.true;
+			expect(args["basisPoint"] == basisPoint).to.be.true;
+
+			// vested SOV rewards
+			expect((await lockedSOV.getLockedBalance(borrower)).toString()).to.eq(new BN(0).toString());
+
+			expect((await lockedSOV.getUnlockedBalance(borrower)).toString()).to.eq(new BN(0).toString());
+		});
+
 		it("Test reduce loan_duration 0 withdraw should fail", async () => {
 			// prepare the test
 			await set_demand_curve(loanToken);


### PR DESCRIPTION
To avoid the clash between SOV for paying the trading rebates and SOV that is used as fees (trading, borrowing, lending) in the protocol, we will introduce an additional check in the Trading Rebate functionality to only use the SOV outside the fees.

Also we will introduce a new getter function which will return the value of SOV that is used to pay the trading rebates. 
the formula will be = SOV Balance of the protocol - (trading, lending, borrowing fees)