### PR TITLE
Feature: Create V2 struct of LoanReturnData

### DIFF
--- a/contracts/interfaces/ISovryn.sol
+++ b/contracts/interfaces/ISovryn.sol
@@ -298,12 +298,30 @@ contract ISovryn is
 		bytes32 loanId;
 		address loanToken;
 		address collateralToken;
-		address borrower;
 		uint256 principal;
 		uint256 collateral;
 		uint256 interestOwedPerDay;
 		uint256 interestDepositRemaining;
 		uint256 startRate; // collateralToLoanRate
+		uint256 startMargin;
+		uint256 maintenanceMargin;
+		uint256 currentMargin;
+		uint256 maxLoanTerm;
+		uint256 endTimestamp;
+		uint256 maxLiquidatable;
+		uint256 maxSeizable;
+	}
+
+	struct LoanReturnDataV2 {
+		bytes32 loanId;
+		address loanToken;
+		address collateralToken;
+		address borrower;
+		uint256 principal;
+		uint256 collateral;
+		uint256 interestOwedPerDay;
+		uint256 interestDepositRemaining;
+		uint256 startRate; /// collateralToLoanRate
 		uint256 startMargin;
 		uint256 maintenanceMargin;
 		uint256 currentMargin;
@@ -323,13 +341,30 @@ contract ISovryn is
 		bool unsafeOnly
 	) external view returns (LoanReturnData[] memory loansData);
 
+	function getUserLoansV2(
+		address user,
+		uint256 start,
+		uint256 count,
+		uint256 loanType,
+		bool isLender,
+		bool unsafeOnly
+	) external view returns (LoanReturnDataV2[] memory loansDataV2);
+
 	function getLoan(bytes32 loanId) external view returns (LoanReturnData memory loanData);
+
+	function getLoanV2(bytes32 loanId) external view returns (LoanReturnDataV2 memory loanDataV2);
 
 	function getActiveLoans(
 		uint256 start,
 		uint256 count,
 		bool unsafeOnly
 	) external view returns (LoanReturnData[] memory loansData);
+
+	function getActiveLoansV2(
+		uint256 start,
+		uint256 count,
+		bool unsafeOnly
+	) external view returns (LoanReturnDataV2[] memory loansDataV2);
 
 	////// Protocol Migration //////
 

--- a/interfaces/ISovrynBrownie.sol
+++ b/interfaces/ISovrynBrownie.sol
@@ -297,12 +297,30 @@ contract ISovrynBrownie is
 		bytes32 loanId;
 		address loanToken;
 		address collateralToken;
-		address borrower;
 		uint256 principal;
 		uint256 collateral;
 		uint256 interestOwedPerDay;
 		uint256 interestDepositRemaining;
 		uint256 startRate; // collateralToLoanRate
+		uint256 startMargin;
+		uint256 maintenanceMargin;
+		uint256 currentMargin;
+		uint256 maxLoanTerm;
+		uint256 endTimestamp;
+		uint256 maxLiquidatable;
+		uint256 maxSeizable;
+	}
+
+	struct LoanReturnDataV2 {
+		bytes32 loanId;
+		address loanToken;
+		address collateralToken;
+		address borrower;
+		uint256 principal;
+		uint256 collateral;
+		uint256 interestOwedPerDay;
+		uint256 interestDepositRemaining;
+		uint256 startRate; /// collateralToLoanRate
 		uint256 startMargin;
 		uint256 maintenanceMargin;
 		uint256 currentMargin;
@@ -322,13 +340,30 @@ contract ISovrynBrownie is
 		bool unsafeOnly
 	) external view returns (LoanReturnData[] memory loansData);
 
+	function getUserLoansV2(
+		address user,
+		uint256 start,
+		uint256 count,
+		uint256 loanType,
+		bool isLender,
+		bool unsafeOnly
+	) external view returns (LoanReturnDataV2[] memory loansDataV2);
+
 	function getLoan(bytes32 loanId) external view returns (LoanReturnData memory loanData);
+
+	function getLoanV2(bytes32 loanId) external view returns (LoanReturnDataV2 memory loanDataV2);
 
 	function getActiveLoans(
 		uint256 start,
 		uint256 count,
 		bool unsafeOnly
 	) external view returns (LoanReturnData[] memory loansData);
+
+	function getActiveLoansV2(
+		uint256 start,
+		uint256 count,
+		bool unsafeOnly
+	) external view returns (LoanReturnData2[] memory loansDataV2);
 
 	////// Protocol Migration //////
 

--- a/interfaces/ISovrynBrownie.sol
+++ b/interfaces/ISovrynBrownie.sol
@@ -363,7 +363,7 @@ contract ISovrynBrownie is
 		uint256 start,
 		uint256 count,
 		bool unsafeOnly
-	) external view returns (LoanReturnData2[] memory loansDataV2);
+	) external view returns (LoanReturnDataV2[] memory loansDataV2);
 
 	////// Protocol Migration //////
 

--- a/tests/loan-token/tradingFunctions.js
+++ b/tests/loan-token/tradingFunctions.js
@@ -94,7 +94,8 @@ const margin_trading_sending_loan_tokens = async (accounts, sovryn, loanToken, u
 	//TODO: problem: rounding error somewhere
 
 	const loan_id = args["loanId"];
-	const loan = await sovryn.getLoanV2(loan_id);
+	const loan = await sovryn.getLoan(loan_id);
+	const loanV2 = await sovryn.getLoanV2(loan_id);
 	const end_timestamp = loan["endTimestamp"];
 	const num = await blockNumber();
 	let currentBlock = await web3.eth.getBlock(num);
@@ -119,8 +120,25 @@ const margin_trading_sending_loan_tokens = async (accounts, sovryn, loanToken, u
 	expect(new BN(block_timestamp).add(max_loan_duration).sub(new BN(end_timestamp)).lt(new BN(1))).to.be.true;
 	expect(loan["maxLiquidatable"]).to.eq("0");
 	expect(loan["maxSeizable"]).to.eq("0");
-	expect(loan["borrower"]).to.eq(accounts[0]);
-	expect(loan["creationTimestamp"]).to.eq(block_timestamp.toString());
+
+	// validate loanV2 data struct
+	expect(loanV2["loanToken"]).to.equal(underlyingToken.address);
+	expect(loanV2["collateralToken"]).to.equal(collateralToken.address);
+	expect(loanV2["principal"]).to.equal(principal.toString());
+	expect(loanV2["collateral"]).to.equal(collateral.toString());
+
+	expect(loanV2["interestOwedPerDay"]).to.equal(owed_per_day.toString());
+	expect(loanV2["interestDepositRemaining"]).to.eq(interest_deposit_remaining.toString());
+	expect(loanV2["startRate"]).to.eq(collateral_to_loan_swap_rate.toString());
+	expect(loanV2["startMargin"]).to.eq(start_margin.toString());
+	expect(loanV2["maintenanceMargin"]).to.eq(new BN(15).mul(oneEth).toString());
+	expect(loanV2["currentMargin"]).to.eq(current_margin.toString());
+	expect(loanV2["maxLoanTerm"]).to.eq(max_loan_duration.toString()); // In the SC is hardcoded to 28 days
+
+	expect(loanV2["maxLiquidatable"]).to.eq("0");
+	expect(loanV2["maxSeizable"]).to.eq("0");
+	expect(loanV2["borrower"]).to.eq(accounts[0]);
+	expect(loanV2["creationTimestamp"]).to.eq(block_timestamp.toString());
 };
 
 const margin_trading_sov_reward_payment = async (accounts, loanToken, underlyingToken, collateralToken, SOV, FeesEvents, sovryn) => {

--- a/tests/loan-token/tradingFunctions.js
+++ b/tests/loan-token/tradingFunctions.js
@@ -94,7 +94,7 @@ const margin_trading_sending_loan_tokens = async (accounts, sovryn, loanToken, u
 	//TODO: problem: rounding error somewhere
 
 	const loan_id = args["loanId"];
-	const loan = await sovryn.getLoan(loan_id);
+	const loan = await sovryn.getLoanV2(loan_id);
 	const end_timestamp = loan["endTimestamp"];
 	const num = await blockNumber();
 	let currentBlock = await web3.eth.getBlock(num);


### PR DESCRIPTION
We need to keep the old LoanReturnData struct as it is, to support the backward compatibility (especially for watchers).
At the same time, returning the borrower address & creationTimestamp in the LoanData struct can improve the scalability for the backend process.
So the solution is introducing the new struct of LoanReturnData called LoanReturnDataV2, which will contain all of the old LoanReturnData + borrower address + creationTime of the loan.