### PR TITLE
Introduce threshold for proposal cancellation by guardian

### DIFF
--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -44,14 +44,14 @@ contract GovernorAlpha is SafeMath96 {
 		return 2880;
 	} // ~1 day in blocks (assuming 30s blocks)
 
-	/// @notice Threshold for total votes proposal to be able to cancelled by guardian.
-	/// TODO finalized this value
+	/// @notice Limitation of guardian power to veto proposal.
+	/// TODO refine this value
 	function totalVotesForCancellationThreshold() public pure returns (uint256) {
 		return 50000000;
 	}
 
 	/// @notice Threshold for total participant of the proposal to be able to cancelled by guardian.
-	/// TODO finalized this value
+	/// TODO refine this value
 	function participantForCancellationThreshold() public pure returns (uint256) {
 		return 50000000;
 	}
@@ -360,7 +360,7 @@ contract GovernorAlpha is SafeMath96 {
 		require(
 			totalFavorVotes <= totalVotesForCancellationThreshold() || // check total Votes (assuming not percentage)
 				totalVotes <= participantForCancellationThreshold(),
-			"Proposal can't be cancelled anymore" /// check total participant.
+			"GovernorAlpha::cancel: guardian veto limitation" /// check total participant.
 		);
 
 		proposal.canceled = true;

--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -52,7 +52,7 @@ contract GovernorAlpha is SafeMath96 {
 
 	/// @notice Threshold for total participant of the proposal to be able to cancelled by guardian.
 	/// TODO finalized this value
-	function participantForCancellationThreshold() public pure returns(uint256) {
+	function participantForCancellationThreshold() public pure returns (uint256) {
 		return 50000000;
 	}
 
@@ -359,7 +359,8 @@ contract GovernorAlpha is SafeMath96 {
 		uint96 totalVotes = add96(totalFavorVotes, proposal.againstVotes, "GovernorAlpha:: state: forVotes + againstVotes > uint96");
 		require(
 			totalFavorVotes <= totalVotesForCancellationThreshold() || // check total Votes (assuming not percentage)
-			totalVotes <=  participantForCancellationThreshold(), "Proposal can't be cancelled anymore" /// check total participant.
+				totalVotes <= participantForCancellationThreshold(),
+			"Proposal can't be cancelled anymore" /// check total participant.
 		);
 
 		proposal.canceled = true;

--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -361,11 +361,13 @@ contract GovernorAlpha is SafeMath96 {
 		uint96 totalFavorVotes = proposal.forVotes;
 		uint96 totalVotes = add96(totalFavorVotes, proposal.againstVotes, "GovernorAlpha:: state: forVotes + againstVotes > uint96");
 		uint96 favorVotesPercentage =
-			div96(
-				mul96(totalFavorVotes, 100, "GovernorAlpha:: state: mul error votes%"),
-				totalVotes,
-				"GovernorAlpha:: state: division error votes%"
-			);
+			totalFavorVotes > 0
+				? div96(
+					mul96(totalFavorVotes, 100, "GovernorAlpha:: state: mul error votes%"),
+					totalVotes,
+					"GovernorAlpha:: state: division error votes%"
+				)
+				: 0;
 		uint96 totalQuorumPercentage =
 			div96(
 				mul96(totalVotes, 100, "GovernorAlpha:: state: division error quorum%"),

--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -63,10 +63,10 @@ contract GovernorAlpha is SafeMath96 {
 	uint96 public majorityPercentageVotes;
 
 	/// @notice Threshold for total favorVotes of the proposal to be able to cancelled by guardian (in percentage).
-	uint256 public constant totalVotesForCancellationThreshold = 80; // 80%
+	uint256 public constant TOTAL_VOTES_CANCELLATION_THRESHOLD = 80; // 80%
 
 	/// @notice Threshold for total participant of the proposal to be able to cancelled by guardian (in percentage).
-	uint256 public constant participantForCancellationThreshold = 80; // 80%
+	uint256 public constant TOTAL_PARTICIPANT_CANCELLATION_THRESHOLD = 80; // 80%
 
 	struct Proposal {
 		/// @notice Unique id for looking up a proposal.
@@ -370,7 +370,7 @@ contract GovernorAlpha is SafeMath96 {
 			);
 
 		require(
-			favorVotesPercentage < totalVotesForCancellationThreshold || totalQuorumPercentage < participantForCancellationThreshold,
+			favorVotesPercentage < TOTAL_VOTES_CANCELLATION_THRESHOLD || totalQuorumPercentage < TOTAL_PARTICIPANT_CANCELLATION_THRESHOLD,
 			"GovernorAlpha::cancel: guardian veto limitation"
 		);
 

--- a/contracts/mockup/GovernorAlphaMockup.sol
+++ b/contracts/mockup/GovernorAlphaMockup.sol
@@ -21,14 +21,4 @@ contract GovernorAlphaMockup is GovernorAlpha {
 			queue(proposalIds[i]);
 		}
 	}
-
-	/// @notice Threshold for total votes proposal to be able to cancelled by guardian.
-	function totalVotesForCancellationThreshold() public pure returns (uint256) {
-		return 9000000;
-	}
-
-	/// @notice Threshold for total participant of the proposal to be able to cancelled by guardian.
-	function participantForCancellationThreshold() public pure returns (uint256) {
-		return 20000000;
-	}
 }

--- a/contracts/mockup/GovernorAlphaMockup.sol
+++ b/contracts/mockup/GovernorAlphaMockup.sol
@@ -28,7 +28,7 @@ contract GovernorAlphaMockup is GovernorAlpha {
 	}
 
 	/// @notice Threshold for total participant of the proposal to be able to cancelled by guardian.
-	function participantForCancellationThreshold() public pure returns(uint256) {
+	function participantForCancellationThreshold() public pure returns (uint256) {
 		return 20000000;
 	}
 }

--- a/contracts/mockup/GovernorAlphaMockup.sol
+++ b/contracts/mockup/GovernorAlphaMockup.sol
@@ -21,4 +21,14 @@ contract GovernorAlphaMockup is GovernorAlpha {
 			queue(proposalIds[i]);
 		}
 	}
+
+	/// @notice Threshold for total votes proposal to be able to cancelled by guardian.
+	function totalVotesForCancellationThreshold() public pure returns (uint256) {
+		return 9000000;
+	}
+
+	/// @notice Threshold for total participant of the proposal to be able to cancelled by guardian.
+	function participantForCancellationThreshold() public pure returns(uint256) {
+		return 20000000;
+	}
 }

--- a/tests/Governance/GovernorAlpha/StateTest.js
+++ b/tests/Governance/GovernorAlpha/StateTest.js
@@ -114,9 +114,10 @@ contract("GovernorAlpha#state/1", (accounts) => {
 		await gov.propose(targets, values, signatures, callDatas, "do nothing", { from: acct });
 		let newProposalId = await gov.proposalCount.call();
 
-		await gov.cancel(newProposalId);
+		// Not able to cancel with 0 total votes.
+		await expectRevert(gov.cancel(newProposalId), "GovernorAlpha:: state: division error totalVotes%");
 
-		expect((await gov.state.call(newProposalId)).toString()).to.be.equal(states["Canceled"]);
+		expect((await gov.state.call(newProposalId)).toString()).to.be.equal(states["Pending"]);
 	});
 
 	it("Defeated by time", async () => {

--- a/tests/Governance/GovernorAlpha/guardian.test.js
+++ b/tests/Governance/GovernorAlpha/guardian.test.js
@@ -299,7 +299,7 @@ contract("GovernorAlpha (Guardian Functions)", (accounts) => {
 
 		// Votes in majority.
 		await governorAlpha.castVote(proposalId, true, { from: voterOne });
-		await governorAlpha.castVote(proposalId, false, { from: voterThree });
+		await governorAlpha.castVote(proposalId, true, { from: voterThree });
 
 		// Cancels the proposal by guardian.
 		await expectRevert(governorAlpha.cancel(proposalId, { from: guardianOne }), "GovernorAlpha::cancel: guardian veto limitation");

--- a/tests/Governance/GovernorAlpha/guardian.test.js
+++ b/tests/Governance/GovernorAlpha/guardian.test.js
@@ -302,7 +302,7 @@ contract("GovernorAlpha (Guardian Functions)", (accounts) => {
 		await governorAlpha.castVote(proposalId, false, { from: voterThree });
 
 		// Cancels the proposal by guardian.
-		await expectRevert(governorAlpha.cancel(proposalId, { from: guardianOne }),  "Proposal can't be cancelled anymore");
+		await expectRevert(governorAlpha.cancel(proposalId, { from: guardianOne }), "Proposal can't be cancelled anymore");
 	});
 
 	it("Remove a successful proposal which was queued even if successful (totalVotes still below the threshold)", async () => {

--- a/tests/Governance/GovernorAlpha/guardian.test.js
+++ b/tests/Governance/GovernorAlpha/guardian.test.js
@@ -306,7 +306,7 @@ contract("GovernorAlpha (Guardian Functions)", (accounts) => {
 	});
 
 	it("Remove a successful proposal which was queued even if successful (totalVotes still below the threshold)", async () => {
-		const amount = new BN((2 * totalSupply) / 100); /// stake 2%
+		const amount = new BN((20 * totalSupply) / 100); /// stake 20%
 		const voterThree = accounts[3];
 		await testToken.transfer(voterThree, amount, { from: guardianOne });
 		await stake(testToken, stakingLogic, voterThree, constants.ZERO_ADDRESS, amount);
@@ -318,7 +318,8 @@ contract("GovernorAlpha (Guardian Functions)", (accounts) => {
 		await mineBlock();
 
 		// Votes in majority.
-		await governorAlpha.castVote(proposalId, true, { from: voterThree });
+		await governorAlpha.castVote(proposalId, true, { from: voterOne });
+		await governorAlpha.castVote(proposalId, false, { from: voterThree });
 
 		// Cancels the proposal by guardian.
 		await governorAlpha.cancel(proposalId, { from: guardianOne });
@@ -331,7 +332,7 @@ contract("GovernorAlpha (Guardian Functions)", (accounts) => {
 	});
 
 	it("Remove a successful proposal which was queued even if successful (total quorum / participant still below the threshold)", async () => {
-		const amount = new BN((2 * totalSupply) / 100); /// stake 2%
+		const amount = new BN((20 * totalSupply) / 100); /// stake 20%
 		const voterThree = accounts[3];
 		await testToken.transfer(voterThree, amount, { from: guardianOne });
 		await stake(testToken, stakingLogic, voterThree, constants.ZERO_ADDRESS, amount);

--- a/tests/Governance/GovernorAlpha/guardian.test.js
+++ b/tests/Governance/GovernorAlpha/guardian.test.js
@@ -302,7 +302,7 @@ contract("GovernorAlpha (Guardian Functions)", (accounts) => {
 		await governorAlpha.castVote(proposalId, false, { from: voterThree });
 
 		// Cancels the proposal by guardian.
-		await expectRevert(governorAlpha.cancel(proposalId, { from: guardianOne }), "Proposal can't be cancelled anymore");
+		await expectRevert(governorAlpha.cancel(proposalId, { from: guardianOne }), "GovernorAlpha::cancel: guardian veto limitation");
 	});
 
 	it("Remove a successful proposal which was queued even if successful (totalVotes still below the threshold)", async () => {


### PR DESCRIPTION
Currently the Guardian can cancel any proposal as long as it has not been executed.
This PR's objective is to reduce the power of the Guardian by introducing threshold value for `Total Votes / Quorum` & `Total ForVotes / Favor`.
If the Total Votes & Total Favor Votes are greater than the threshold (in percentage), then Guardian won't be able to cancel the proposal anymore.