### PR TITLE
fix WeightedStaking is Checkpoints cyclic reference

### DIFF
--- a/contracts/governance/Staking/IStaking.sol
+++ b/contracts/governance/Staking/IStaking.sol
@@ -46,4 +46,32 @@ interface IStaking {
     function timestampToLockDate(uint256 timestamp) external view returns (uint256 lockDate);
 
     function isVestingContract(address stakerAddress) external view returns (bool);
+
+    function allUnlocked() external view returns (bool);
+
+    function newStakingContract() external view returns (address);
+
+    function getPriorUserStakeByDate(
+        address account,
+        uint256 date,
+        uint256 blockNumber
+    ) external view returns (uint96);
+
+    function governanceWithdraw(
+        uint96 amount,
+        uint256 until,
+        address receiver
+    ) external;
+
+    function withdraw(
+        uint96 amount,
+        uint256 until,
+        address receiver
+    ) external;
+
+    function migrateToNewStakingContract() external;
+
+    function delegate(address delegatee, uint256 lockDate) external;
+
+    function MAX_DURATION() external view returns (uint256);
 }

--- a/contracts/governance/Vesting/VestingLogic.sol
+++ b/contracts/governance/Vesting/VestingLogic.sol
@@ -3,7 +3,7 @@ pragma experimental ABIEncoderV2;
 
 import "../../openzeppelin/Ownable.sol";
 import "../../interfaces/IERC20.sol";
-import "../Staking/Staking.sol";
+import "../Staking/IStaking.sol";
 import "../IFeeSharingProxy.sol";
 import "./IVesting.sol";
 import "../ApprovalReceiver.sol";
@@ -199,7 +199,7 @@ contract VestingLogic is IVesting, VestingStorage, ApprovalReceiver {
      * */
     function migrateToNewStakingContract() public onlyOwners {
         staking.migrateToNewStakingContract();
-        staking = Staking(staking.newStakingContract());
+        staking = IStaking(staking.newStakingContract());
         emit MigratedToNewStakingContract(msg.sender, address(staking));
     }
 

--- a/contracts/governance/Vesting/VestingRegistryStorage.sol
+++ b/contracts/governance/Vesting/VestingRegistryStorage.sol
@@ -21,7 +21,7 @@ contract VestingRegistryStorage is Initializable, AdminRole {
     IVestingFactory public vestingFactory;
 
     ///@notice the Locked SOV contract
-    LockedSOV public lockedSOV;
+    ILockedSOV public lockedSOV;
 
     ///@notice the list of vesting registries
     IVestingRegistry[] public vestingRegistries;

--- a/contracts/governance/Vesting/VestingStorage.sol
+++ b/contracts/governance/Vesting/VestingStorage.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.17;
 
 import "../../openzeppelin/Ownable.sol";
 import "../../interfaces/IERC20.sol";
-import "../Staking/Staking.sol";
+import "../Staking/IStaking.sol";
 import "../IFeeSharingProxy.sol";
 
 /**
@@ -18,7 +18,7 @@ contract VestingStorage is Ownable {
     IERC20 public SOV;
 
     /// @notice The staking contract address.
-    Staking public staking;
+    IStaking public staking;
 
     /// @notice The owner of the vested tokens.
     address public tokenOwner;

--- a/contracts/locked/ILockedSOV.sol
+++ b/contracts/locked/ILockedSOV.sol
@@ -31,4 +31,8 @@ interface ILockedSOV {
      * @param _userAddress The address of user tokens will be withdrawn.
      */
     function withdrawAndStakeTokensFrom(address _userAddress) external;
+
+    function cliff() external view returns (uint256);
+
+    function duration() external view returns (uint256);
 }


### PR DESCRIPTION
No more `Definition of base has to precede definition of derived contract` on Checkpoints in 
`contract WeightedStaking is Checkpoints`.
A bit of optimization - using interfaces as types instead of contracts.