### PR TITLE
100% Liquid Rewards for LM

### DIFF
--- a/contracts/farm/LiquidityMining.sol
+++ b/contracts/farm/LiquidityMining.sol
@@ -606,7 +606,7 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
     ) internal {
         uint256 userAccumulatedReward = _user.accumulatedReward;
         /// @dev get unlock immediate percent of the pool token.
-        uint256 calculatedImmediatelyPercent = calcUnlockedImmediatelyPercent(_poolToken);
+        uint256 calculatedUnlockedImmediatelyPercent = calcUnlockedImmediatelyPercent(_poolToken);
 
         /// @dev Transfer if enough SOV balance on this LM contract.
         uint256 balance = SOV.balanceOf(address(this));
@@ -614,18 +614,18 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
             totalUsersBalance = totalUsersBalance.sub(userAccumulatedReward);
             _user.accumulatedReward = 0;
 
-            /// @dev If calculatedImmediatelyPercent is 100%, transfer the reward to the LP (user).
+            /// @dev If calculatedUnlockedImmediatelyPercent is 100%, transfer the reward to the LP (user).
             ///   else, deposit it into lockedSOV vault contract, but first
             ///   SOV deposit must be approved to move the SOV tokens
             ///   from this LM contract into the lockedSOV vault.
-            if (calculatedImmediatelyPercent == 10000) {
+            if (calculatedUnlockedImmediatelyPercent == 10000) {
                 SOV.transfer(_userAddress, userAccumulatedReward);
             } else {
                 require(SOV.approve(address(lockedSOV), userAccumulatedReward), "Approve failed");
                 lockedSOV.deposit(
                     _userAddress,
                     userAccumulatedReward,
-                    calculatedImmediatelyPercent
+                    calculatedUnlockedImmediatelyPercent
                 );
 
                 if (_isStakingTokens) {
@@ -778,9 +778,12 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
         uint256 result;
         for (uint256 i = 0; i < length; i++) {
             address _poolToken = address(poolInfoList[i].poolToken);
-            uint256 calculatedImmediatelyPercent = calcUnlockedImmediatelyPercent(_poolToken);
+            uint256 calculatedUnlockedImmediatelyPercent =
+                calcUnlockedImmediatelyPercent(_poolToken);
             result = result.add(
-                calculatedImmediatelyPercent.mul(_getUserAccumulatedReward(i, _user)).div(10000)
+                calculatedUnlockedImmediatelyPercent.mul(_getUserAccumulatedReward(i, _user)).div(
+                    10000
+                )
             );
         }
 
@@ -796,9 +799,10 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
         uint256 result;
         for (uint256 i = 0; i < length; i++) {
             address _poolToken = address(poolInfoList[i].poolToken);
-            uint256 calculatedImmediatelyPercent = calcUnlockedImmediatelyPercent(_poolToken);
+            uint256 calculatedUnlockedImmediatelyPercent =
+                calcUnlockedImmediatelyPercent(_poolToken);
             result = result.add(
-                (10000 - calculatedImmediatelyPercent)
+                (10000 - calculatedUnlockedImmediatelyPercent)
                     .mul(_getUserAccumulatedReward(i, _user))
                     .div(10000)
             );

--- a/contracts/farm/LiquidityMining.sol
+++ b/contracts/farm/LiquidityMining.sol
@@ -769,13 +769,16 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
      * @notice returns the accumulated liquid reward for the given user for each pool token
      * @param _user the address of the user
      */
-    function getUserAccumulatedRewardToBePaidLiquid(address _user) external view returns (uint256) {
+    function getUserAccumulatedRewardToBePaidLiquid(address _user)
+        external
+        view
+        returns (uint256)
+    {
         uint256 length = poolInfoList.length;
         uint256 result;
         for (uint256 i = 0; i < length; i++) {
             address _poolToken = address(poolInfoList[i].poolToken);
-            uint256 calculatedImmediatelyPercent =
-                calcUnlockedImmediatelyPercent(_poolToken);
+            uint256 calculatedImmediatelyPercent = calcUnlockedImmediatelyPercent(_poolToken);
             result = result.add(
                 calculatedImmediatelyPercent.mul(_getUserAccumulatedReward(i, _user)).div(10000)
             );
@@ -793,12 +796,11 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
         uint256 result;
         for (uint256 i = 0; i < length; i++) {
             address _poolToken = address(poolInfoList[i].poolToken);
-            uint256 calculatedImmediatelyPercent =
-                calcUnlockedImmediatelyPercent(_poolToken);
+            uint256 calculatedImmediatelyPercent = calcUnlockedImmediatelyPercent(_poolToken);
             result = result.add(
-                (10000 - calculatedImmediatelyPercent).mul(_getUserAccumulatedReward(i, _user)).div(
-                    10000
-                )
+                (10000 - calculatedImmediatelyPercent)
+                    .mul(_getUserAccumulatedReward(i, _user))
+                    .div(10000)
             );
         }
 
@@ -809,12 +811,12 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
      * @dev calculate the unlocked immediate percentage of specific pool token
      * use the poolTokensUnlockedImmediatelyPercent by default, if it is not set, then use the unlockedImmediatelyPercent
      */
-    function calcUnlockedImmediatelyPercent(address _poolToken)
-        public
-        view
-        returns (uint256)
-    {
-        uint256 poolTokenUnlockedImmediatelyPercent = poolTokensUnlockedImmediatelyPercent[_poolToken];
-        return poolTokenUnlockedImmediatelyPercent > 0 ? poolTokenUnlockedImmediatelyPercent : unlockedImmediatelyPercent;
+    function calcUnlockedImmediatelyPercent(address _poolToken) public view returns (uint256) {
+        uint256 poolTokenUnlockedImmediatelyPercent =
+            poolTokensUnlockedImmediatelyPercent[_poolToken];
+        return
+            poolTokenUnlockedImmediatelyPercent > 0
+                ? poolTokenUnlockedImmediatelyPercent
+                : unlockedImmediatelyPercent;
     }
 }

--- a/contracts/farm/LiquidityMining.sol
+++ b/contracts/farm/LiquidityMining.sol
@@ -111,18 +111,18 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
     /**
      * @notice Sets unlocked immediately percent overwrite for specific pool token.
      * @param _poolToken the address of pool token
-     * @param _unlockedImmediatelyPercent The % which determines how much will be unlocked immediately.
+     * @param _poolTokenUnlockedImmediatelyPercent The % which determines how much will be unlocked immediately.
      * @dev 10000 is 100%
      */
-    function setUnlockedImmediatelyPercentOverwrite(
+    function setPoolTokensUnlockedImmediatelyPercent(
         address _poolToken,
-        uint256 _unlockedImmediatelyPercent
+        uint256 _poolTokenUnlockedImmediatelyPercent
     ) external onlyAuthorized {
         require(
-            _unlockedImmediatelyPercent <= 10000,
+            _poolTokenUnlockedImmediatelyPercent <= 10000,
             "Unlocked immediately percent has to be less than equal to 10000."
         );
-        unlockedImmediatelyPercentOverwrite[_poolToken] = _unlockedImmediatelyPercent;
+        poolTokensUnlockedImmediatelyPercent[_poolToken] = _poolTokenUnlockedImmediatelyPercent;
     }
 
     /**
@@ -807,7 +807,7 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
 
     /**
      * @dev get the unlocked immediate percentage of specific pool token
-     * use the unlockedImmediatelyPercentOverwrite by default, if it is not set, then use the unlockedImmediatelyPercent
+     * use the poolTokensUnlockedImmediatelyPercent by default, if it is not set, then use the unlockedImmediatelyPercent
      */
     function _getPoolTokenUnlockedImmediatelyPercent(address _poolToken)
         internal
@@ -815,8 +815,8 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
         returns (uint256)
     {
         return
-            unlockedImmediatelyPercentOverwrite[_poolToken] > 0
-                ? unlockedImmediatelyPercentOverwrite[_poolToken]
+            poolTokensUnlockedImmediatelyPercent[_poolToken] > 0
+                ? poolTokensUnlockedImmediatelyPercent[_poolToken]
                 : unlockedImmediatelyPercent;
     }
 }

--- a/contracts/farm/LiquidityMining.sol
+++ b/contracts/farm/LiquidityMining.sol
@@ -769,46 +769,40 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
      * @notice returns the accumulated liquid reward for the given user for each pool token
      * @param _user the address of the user
      */
-    function getUserAccumulatedLiquidReward(address _user)
-        external
-        view
-        returns (uint256[] memory)
-    {
+    function getUserAccumulatedLiquidReward(address _user) external view returns (uint256) {
         uint256 length = poolInfoList.length;
-        uint256[] memory rewardList = new uint256[](length);
+        uint256 result;
         for (uint256 i = 0; i < length; i++) {
             address _poolToken = address(poolInfoList[i].poolToken);
             uint256 _unlockedImmediatelyPercent =
                 _getPoolTokenUnlockedImmediatelyPercent(_poolToken);
-            rewardList[i] =
-                (_unlockedImmediatelyPercent * _getUserAccumulatedReward(i, _user)) /
-                10000;
+            result = result.add(
+                _unlockedImmediatelyPercent.mul(_getUserAccumulatedReward(i, _user)).div(10000)
+            );
         }
 
-        return rewardList;
+        return result;
     }
 
     /**
      * @notice returns the accumulated vested reward for the given user for each pool token
      * @param _user the address of the user
      */
-    function getUserAccumulatedVestedReward(address _user)
-        external
-        view
-        returns (uint256[] memory)
-    {
+    function getUserAccumulatedVestedReward(address _user) external view returns (uint256) {
         uint256 length = poolInfoList.length;
-        uint256[] memory rewardList = new uint256[](length);
+        uint256 result;
         for (uint256 i = 0; i < length; i++) {
             address _poolToken = address(poolInfoList[i].poolToken);
             uint256 _unlockedImmediatelyPercent =
                 _getPoolTokenUnlockedImmediatelyPercent(_poolToken);
-            rewardList[i] =
-                ((10000 - _unlockedImmediatelyPercent) * _getUserAccumulatedReward(i, _user)) /
-                10000;
+            result = result.add(
+                (10000 - _unlockedImmediatelyPercent).mul(_getUserAccumulatedReward(i, _user)).div(
+                    10000
+                )
+            );
         }
 
-        return rewardList;
+        return result;
     }
 
     /**

--- a/contracts/farm/LiquidityMining.sol
+++ b/contracts/farm/LiquidityMining.sol
@@ -114,7 +114,7 @@ contract LiquidityMining is ILiquidityMining, LiquidityMiningStorage {
      * @param _poolTokenUnlockedImmediatelyPercent The % which determines how much will be unlocked immediately.
      * @dev 10000 is 100%
      */
-    function setPoolTokensUnlockedImmediatelyPercent(
+    function setPoolTokenUnlockedImmediatelyPercent(
         address _poolToken,
         uint256 _poolTokenUnlockedImmediatelyPercent
     ) external onlyAuthorized {

--- a/contracts/farm/LiquidityMiningStorage.sol
+++ b/contracts/farm/LiquidityMiningStorage.sol
@@ -66,4 +66,7 @@ contract LiquidityMiningStorage is AdminRole {
     // The % which determines how much will be unlocked immediately.
     /// @dev 10000 is 100%
     uint256 public unlockedImmediatelyPercent;
+
+    /// @dev overwrite the unlockedImmediatelyPercent for specific token.
+    mapping(address => uint256) public unlockedImmediatelyPercentOverwrite;
 }

--- a/contracts/farm/LiquidityMiningStorage.sol
+++ b/contracts/farm/LiquidityMiningStorage.sol
@@ -68,5 +68,5 @@ contract LiquidityMiningStorage is AdminRole {
     uint256 public unlockedImmediatelyPercent;
 
     /// @dev overwrite the unlockedImmediatelyPercent for specific token.
-    mapping(address => uint256) public unlockedImmediatelyPercentOverwrite;
+    mapping(address => uint256) public poolTokensUnlockedImmediatelyPercent;
 }

--- a/contracts/locked/ILockedSOV.sol
+++ b/contracts/locked/ILockedSOV.sol
@@ -35,4 +35,8 @@ interface ILockedSOV {
     function cliff() external view returns (uint256);
 
     function duration() external view returns (uint256);
+
+    function getLockedBalance(address _addr) external view returns (uint256 _balance);
+
+    function getUnlockedBalance(address _addr) external view returns (uint256 _balance);
 }

--- a/contracts/mockup/LiquidityMiningMockup.sol
+++ b/contracts/mockup/LiquidityMiningMockup.sol
@@ -17,4 +17,12 @@ contract LiquidityMiningMockup is LiquidityMining {
         PoolInfo storage pool = poolInfoList[poolId];
         return _getPoolAccumulatedReward(pool);
     }
+
+    function getPoolTokenUnlockedImmediatelyPercent(address _poolToken)
+        public
+        view
+        returns (uint256)
+    {
+        return _getPoolTokenUnlockedImmediatelyPercent(_poolToken);
+    }
 }

--- a/contracts/mockup/LiquidityMiningMockup.sol
+++ b/contracts/mockup/LiquidityMiningMockup.sol
@@ -17,12 +17,4 @@ contract LiquidityMiningMockup is LiquidityMining {
         PoolInfo storage pool = poolInfoList[poolId];
         return _getPoolAccumulatedReward(pool);
     }
-
-    function getPoolTokenUnlockedImmediatelyPercent(address _poolToken)
-        public
-        view
-        returns (uint256)
-    {
-        return _getPoolTokenUnlockedImmediatelyPercent(_poolToken);
-    }
 }

--- a/tests/farm/LiquidityMining.js
+++ b/tests/farm/LiquidityMining.js
@@ -1680,12 +1680,12 @@ contract("LiquidityMining", (accounts) => {
              *      - Token 2: 100%
              *      - Token 3: 30%
              * 3. Deposit into LM for those 3 tokens
-             * 4. getUserAccumulatedLiquidReward should return array that consist of:
+             * 4. getUserAccumulatedLiquidReward should return SUM of these 3 rewards:
              *      - Token 1: 0% amount reward of token 1
              *      - Token 2: 100% amount reward of token 2
              *      - Token 3: 30% amount reward of token 3
              * 5. claim all rewards
-             * 6. getUserAccumulatedLiquidReward should return 0 value for all of those 3 tokens.
+             * 6. getUserAccumulatedLiquidReward should return 0 value.
              */
             await liquidityMining.add(token3.address, allocationPoint, false);
             await token3.mint(account1, amount);
@@ -1741,21 +1741,18 @@ contract("LiquidityMining", (accounts) => {
                 await liquidityMining.getUserAccumulatedRewardList(account1);
             const previousAccumulatedLiquidReward =
                 await liquidityMining.getUserAccumulatedLiquidReward(account1);
-            expect(previousAccumulatedLiquidReward).to.be.an("array");
-            expect(previousAccumulatedLiquidReward[0]).to.equal(
-                unlockImmediatelyPercentToken1
-                    .mul(peviousAccumulatedRewardList[0])
-                    .div(HUNDRED_PERCENT)
-            );
-            expect(previousAccumulatedLiquidReward[1]).to.equal(
-                unlockImmediatelyPercentToken2
-                    .mul(peviousAccumulatedRewardList[1])
-                    .div(HUNDRED_PERCENT)
-            );
-            expect(previousAccumulatedLiquidReward[2]).to.equal(
-                unlockImmediatelyPercentToken3
-                    .mul(peviousAccumulatedRewardList[2])
-                    .div(HUNDRED_PERCENT)
+
+            const liquidRewardToken1 = unlockImmediatelyPercentToken1
+                .mul(peviousAccumulatedRewardList[0])
+                .div(HUNDRED_PERCENT);
+            const liquidRewardToken2 = unlockImmediatelyPercentToken2
+                .mul(peviousAccumulatedRewardList[1])
+                .div(HUNDRED_PERCENT);
+            const liquidRewardToken3 = unlockImmediatelyPercentToken3
+                .mul(peviousAccumulatedRewardList[2])
+                .div(HUNDRED_PERCENT);
+            expect(previousAccumulatedLiquidReward).to.equal(
+                liquidRewardToken1.add(liquidRewardToken2).add(liquidRewardToken3)
             );
 
             await liquidityMining.claimRewardFromAllPools(ZERO_ADDRESS, {
@@ -1771,10 +1768,7 @@ contract("LiquidityMining", (accounts) => {
 
             const latestAccumulatedLiquidReward =
                 await liquidityMining.getUserAccumulatedLiquidReward(account1);
-            expect(latestAccumulatedLiquidReward).to.be.an("array");
-            expect(latestAccumulatedLiquidReward[0]).to.equal("0");
-            expect(latestAccumulatedLiquidReward[1]).to.equal("0");
-            expect(latestAccumulatedLiquidReward[2]).to.equal("0");
+            expect(latestAccumulatedLiquidReward).to.equal("0");
         });
 
         it("getUserAccumulatedVestedReward should return correct value", async () => {
@@ -1785,12 +1779,12 @@ contract("LiquidityMining", (accounts) => {
              *      - Token 2: 100%
              *      - Token 3: 30%
              * 3. Deposit into LM for those 3 tokens
-             * 4. getUserAccumulatedVestedReward should return array that consist of:
+             * 4. getUserAccumulatedVestedReward should return SUM of these 3 rewards:
              *      - Token 1: 100% amount reward of token 1
              *      - Token 2: 0% amount reward of token 2
              *      - Token 3: 70% amount reward of token 3
              * 5. claim all rewards
-             * 6. getUserAccumulatedVestedReward should return 0 value for all of those 3 tokens.
+             * 6. getUserAccumulatedVestedReward should return 0 value.
              */
             await liquidityMining.add(token3.address, allocationPoint, false);
             await token3.mint(account1, amount);
@@ -1846,21 +1840,18 @@ contract("LiquidityMining", (accounts) => {
                 await liquidityMining.getUserAccumulatedRewardList(account1);
             const previousAccumulatedVestedReward =
                 await liquidityMining.getUserAccumulatedVestedReward(account1);
-            expect(previousAccumulatedVestedReward).to.be.an("array");
-            expect(previousAccumulatedVestedReward[0]).to.equal(
-                HUNDRED_PERCENT.sub(unlockImmediatelyPercentToken1)
-                    .mul(peviousAccumulatedRewardList[0])
-                    .div(HUNDRED_PERCENT)
-            );
-            expect(previousAccumulatedVestedReward[1]).to.equal(
-                HUNDRED_PERCENT.sub(unlockImmediatelyPercentToken2)
-                    .mul(peviousAccumulatedRewardList[1])
-                    .div(HUNDRED_PERCENT)
-            );
-            expect(previousAccumulatedVestedReward[2]).to.equal(
-                HUNDRED_PERCENT.sub(unlockImmediatelyPercentToken3)
-                    .mul(peviousAccumulatedRewardList[2])
-                    .div(HUNDRED_PERCENT)
+
+            const vestedRewardToken1 = HUNDRED_PERCENT.sub(unlockImmediatelyPercentToken1)
+                .mul(peviousAccumulatedRewardList[0])
+                .div(HUNDRED_PERCENT);
+            const vestedRewardToken2 = HUNDRED_PERCENT.sub(unlockImmediatelyPercentToken2)
+                .mul(peviousAccumulatedRewardList[1])
+                .div(HUNDRED_PERCENT);
+            const vestedRewardToken3 = HUNDRED_PERCENT.sub(unlockImmediatelyPercentToken3)
+                .mul(peviousAccumulatedRewardList[2])
+                .div(HUNDRED_PERCENT);
+            expect(previousAccumulatedVestedReward).to.equal(
+                vestedRewardToken1.add(vestedRewardToken2).add(vestedRewardToken3)
             );
 
             await liquidityMining.claimRewardFromAllPools(ZERO_ADDRESS, {
@@ -1876,10 +1867,7 @@ contract("LiquidityMining", (accounts) => {
 
             const latestAccumulatedVestedReward =
                 await liquidityMining.getUserAccumulatedVestedReward(account1);
-            expect(latestAccumulatedVestedReward).to.be.an("array");
-            expect(latestAccumulatedVestedReward[0]).to.equal("0");
-            expect(latestAccumulatedVestedReward[1]).to.equal("0");
-            expect(latestAccumulatedVestedReward[2]).to.equal("0");
+            expect(latestAccumulatedVestedReward).to.equal("0");
         });
     });
 

--- a/tests/farm/LiquidityMining.js
+++ b/tests/farm/LiquidityMining.js
@@ -343,7 +343,7 @@ contract("LiquidityMining", (accounts) => {
         });
     });
 
-    describe("setPoolTokensUnlockedImmediatelyPercent", () => {
+    describe("setPoolTokenUnlockedImmediatelyPercent", () => {
         it("should use the poolTokensUnlockedImmediatelyPercent by default", async () => {
             // should use unlockedImmediatelyPercent by default
             const unlockedImmediatelyPercent = await liquidityMining.unlockedImmediatelyPercent();
@@ -355,7 +355,7 @@ contract("LiquidityMining", (accounts) => {
 
             // set the poolTokensUnlockedImmediatelyPercent
             let newpoolTokensUnlockedImmediatelyPercent = new BN(3000);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token1.address,
                 newpoolTokensUnlockedImmediatelyPercent
             );
@@ -385,7 +385,7 @@ contract("LiquidityMining", (accounts) => {
 
             // set the poolTokensUnlockedImmediatelyPercent to 0
             newpoolTokensUnlockedImmediatelyPercent = new BN(0);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token1.address,
                 newpoolTokensUnlockedImmediatelyPercent
             );
@@ -401,7 +401,7 @@ contract("LiquidityMining", (accounts) => {
 
         it("sets the expected values", async () => {
             let newpoolTokensUnlockedImmediatelyPercent = new BN(2000);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token1.address,
                 newpoolTokensUnlockedImmediatelyPercent
             );
@@ -421,7 +421,7 @@ contract("LiquidityMining", (accounts) => {
 
         it("successfully set to 10000 (100%)", async () => {
             let newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token1.address,
                 newpoolTokensUnlockedImmediatelyPercent
             );
@@ -442,21 +442,21 @@ contract("LiquidityMining", (accounts) => {
         it("fails if not an owner or an admin", async () => {
             await deploymentAndInit();
             await expectRevert(
-                liquidityMining.setPoolTokensUnlockedImmediatelyPercent(token1.address, 1000, {
+                liquidityMining.setPoolTokenUnlockedImmediatelyPercent(token1.address, 1000, {
                     from: account1,
                 }),
                 "unauthorized"
             );
 
             await liquidityMining.addAdmin(account1);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(token1.address, 1000, {
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(token1.address, 1000, {
                 from: account1,
             });
         });
 
         it("fails if unlockedImmediatelyPercent > 10000", async () => {
             await expectRevert(
-                liquidityMining.setPoolTokensUnlockedImmediatelyPercent(token1.address, 10001),
+                liquidityMining.setPoolTokenUnlockedImmediatelyPercent(token1.address, 10001),
                 "Unlocked immediately percent has to be less than equal to 10000."
             );
         });
@@ -1002,7 +1002,7 @@ contract("LiquidityMining", (accounts) => {
              *      - 100% of token1 reward will be transferred directly to the user.
              */
             const newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token1.address,
                 newpoolTokensUnlockedImmediatelyPercent
             );
@@ -1075,7 +1075,7 @@ contract("LiquidityMining", (accounts) => {
              */
             // set the unlockedImmediatelyOverwrite to 30%
             const newpoolTokensUnlockedImmediatelyPercent = new BN(3000);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token1.address,
                 newpoolTokensUnlockedImmediatelyPercent
             );
@@ -1419,7 +1419,7 @@ contract("LiquidityMining", (accounts) => {
 
             // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
             const newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token2.address,
                 newpoolTokensUnlockedImmediatelyPercent
             );
@@ -1536,7 +1536,7 @@ contract("LiquidityMining", (accounts) => {
 
             // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
             const newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token2.address,
                 newpoolTokensUnlockedImmediatelyPercent
             );
@@ -1697,13 +1697,13 @@ contract("LiquidityMining", (accounts) => {
 
             // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
             const newpoolTokensUnlockedImmediatelyPercent2 = new BN(10000);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token2.address,
                 newpoolTokensUnlockedImmediatelyPercent2
             );
 
             const newpoolTokensUnlockedImmediatelyPercent3 = new BN(3000);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token3.address,
                 newpoolTokensUnlockedImmediatelyPercent3
             );
@@ -1796,13 +1796,13 @@ contract("LiquidityMining", (accounts) => {
 
             // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
             const newpoolTokensUnlockedImmediatelyPercent2 = new BN(10000);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token2.address,
                 newpoolTokensUnlockedImmediatelyPercent2
             );
 
             const newpoolTokensUnlockedImmediatelyPercent3 = new BN(3000);
-            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token3.address,
                 newpoolTokensUnlockedImmediatelyPercent3
             );

--- a/tests/farm/LiquidityMining.js
+++ b/tests/farm/LiquidityMining.js
@@ -42,6 +42,7 @@ contract("LiquidityMining", (accounts) => {
     const rewardTokensPerBlock = new BN(3);
     const startDelayBlocks = new BN(1);
     const numberOfBonusBlocks = new BN(50);
+    const HUNDRED_PERCENT = new BN(10000);
 
     // The % which determines how much will be unlocked immediately.
     /// @dev 10000 is 100%
@@ -315,6 +316,14 @@ contract("LiquidityMining", (accounts) => {
             expect(_unlockedImmediatelyPercent).bignumber.equal(newUnlockedImmediatelyPercent);
         });
 
+        it("successfully set to 10000 (100%)", async () => {
+            let newUnlockedImmediatelyPercent = new BN(10000);
+            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
+
+            let _unlockedImmediatelyPercent = await liquidityMining.unlockedImmediatelyPercent();
+            expect(_unlockedImmediatelyPercent).bignumber.equal(newUnlockedImmediatelyPercent);
+        });
+
         it("fails if not an owner or an admin", async () => {
             await deploymentAndInit();
             await expectRevert(
@@ -326,10 +335,129 @@ contract("LiquidityMining", (accounts) => {
             await liquidityMining.setUnlockedImmediatelyPercent(1000, { from: account1 });
         });
 
-        it("fails if unlockedImmediatelyPercent >= 10000", async () => {
+        it("fails if unlockedImmediatelyPercent > 10000", async () => {
             await expectRevert(
-                liquidityMining.setUnlockedImmediatelyPercent(100000),
-                "Unlocked immediately percent has to be less than 10000."
+                liquidityMining.setUnlockedImmediatelyPercent(10001),
+                "Unlocked immediately percent has to be less than equal to 10000."
+            );
+        });
+    });
+
+    describe("setUnlockedImmediatelyPercentOverwrite", () => {
+        it("should use the unlockedImmediatelyPercentOverwrite by default", async () => {
+            // should use unlockedImmediatelyPercent by default
+            const unlockedImmediatelyPercent = await liquidityMining.unlockedImmediatelyPercent();
+            let previousPoolTokenUnlockedImmediatelyPercent =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(previousPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
+                unlockedImmediatelyPercent
+            );
+
+            // set the unlockedImmediatelyPercentOverwrite
+            let newUnlockedImmediatelyPercentOverwrite = new BN(3000);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token1.address,
+                newUnlockedImmediatelyPercentOverwrite
+            );
+
+            let _unlockedImmediatelyPercentOverwrite =
+                await liquidityMining.unlockedImmediatelyPercentOverwrite(token1.address);
+            expect(_unlockedImmediatelyPercentOverwrite).bignumber.equal(
+                newUnlockedImmediatelyPercentOverwrite
+            );
+
+            let latestPoolTokenUnlockedImmediatelyPercent =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(latestPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
+                newUnlockedImmediatelyPercentOverwrite
+            );
+        });
+
+        it("should use the unlockedImmediatelyPercent if unlockedImmediatelyPercentOverwrite is updated to 0", async () => {
+            // getPoolTokenUnlockedImmediatelyPercent should use the unlockedImmediatelyPercentOverwrite since it was set from the previous test
+            const unlockedImmediatelyPercentOverwrite =
+                await liquidityMining.unlockedImmediatelyPercentOverwrite(token1.address);
+            const previousPoolTokenUnlockedImmediatelyPercent =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(previousPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
+                unlockedImmediatelyPercentOverwrite
+            );
+
+            // set the unlockedImmediatelyPercentOverwrite to 0
+            newUnlockedImmediatelyPercentOverwrite = new BN(0);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token1.address,
+                newUnlockedImmediatelyPercentOverwrite
+            );
+
+            // getPoolTokenUnlockedImmediatelyPercent should use the unlockedImmediatelyPercent
+            const unlockedImmediatelyPercent = await liquidityMining.unlockedImmediatelyPercent();
+            const latestPoolTokenUnlockedImmediatelyPercent =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(latestPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
+                unlockedImmediatelyPercent
+            );
+        });
+
+        it("sets the expected values", async () => {
+            let newUnlockedImmediatelyPercentOverwrite = new BN(2000);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token1.address,
+                newUnlockedImmediatelyPercentOverwrite
+            );
+
+            let _unlockedImmediatelyPercentOverwrite =
+                await liquidityMining.unlockedImmediatelyPercentOverwrite(token1.address);
+            expect(_unlockedImmediatelyPercentOverwrite).bignumber.equal(
+                newUnlockedImmediatelyPercentOverwrite
+            );
+
+            let latestPoolTokenUnlockedImmediatelyPercent =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(latestPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
+                newUnlockedImmediatelyPercentOverwrite
+            );
+        });
+
+        it("successfully set to 10000 (100%)", async () => {
+            let newUnlockedImmediatelyPercentOverwrite = new BN(10000);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token1.address,
+                newUnlockedImmediatelyPercentOverwrite
+            );
+
+            let _unlockedImmediatelyPercentOverwrite =
+                await liquidityMining.unlockedImmediatelyPercentOverwrite(token1.address);
+            expect(_unlockedImmediatelyPercentOverwrite).bignumber.equal(
+                newUnlockedImmediatelyPercentOverwrite
+            );
+
+            let latestPoolTokenUnlockedImmediatelyPercent =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(latestPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
+                newUnlockedImmediatelyPercentOverwrite
+            );
+        });
+
+        it("fails if not an owner or an admin", async () => {
+            await deploymentAndInit();
+            await expectRevert(
+                liquidityMining.setUnlockedImmediatelyPercentOverwrite(token1.address, 1000, {
+                    from: account1,
+                }),
+                "unauthorized"
+            );
+
+            await liquidityMining.addAdmin(account1);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(token1.address, 1000, {
+                from: account1,
+            });
+        });
+
+        it("fails if unlockedImmediatelyPercent > 10000", async () => {
+            await expectRevert(
+                liquidityMining.setUnlockedImmediatelyPercentOverwrite(token1.address, 10001),
+                "Unlocked immediately percent has to be less than equal to 10000."
             );
         });
     });
@@ -727,12 +855,14 @@ contract("LiquidityMining", (accounts) => {
             );
         });
 
-        it("should be able to claim reward (will be claimed with SOV tokens)", async () => {
+        it("should be able to claim reward (will be claimed with SOV tokens) with 10% of unlockedImmediatelyPercent", async () => {
             let depositTx = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
                 from: account1,
             });
             let depositBlockNumber = new BN(depositTx.receipt.blockNumber);
             await SOVToken.transfer(liquidityMining.address, new BN(1000));
+
+            const previousUserSOVBalance = await SOVToken.balanceOf(account1);
 
             let tx = await liquidityMining.claimReward(token1.address, ZERO_ADDRESS, {
                 from: account1,
@@ -765,11 +895,241 @@ contract("LiquidityMining", (accounts) => {
             expect(unlockedBalance).bignumber.equal(new BN(0));
             expect(lockedBalance).bignumber.equal(new BN(0));
 
+            const latestUserSOVBalance = await SOVToken.balanceOf(account1);
+
+            /** user should only receive 10% SOV since the unlockedImmediatelyPercent is 10% */
+            const unlockImmediatelyPercent =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(latestUserSOVBalance.toString()).to.equal(
+                previousUserSOVBalance.add(
+                    userReward.mul(unlockImmediatelyPercent).div(HUNDRED_PERCENT)
+                )
+            );
+
             expectEvent(tx, "RewardClaimed", {
                 user: account1,
                 poolToken: token1.address,
                 amount: userReward,
             });
+
+            // the other 90% of reward claimed will be staked
+            await expectEvent.inTransaction(
+                tx.receipt.rawLogs[0].transactionHash,
+                lockedSOV,
+                "TokensStaked",
+                {
+                    _initiator: account1,
+                    _vesting: ZERO_ADDRESS,
+                    _amount: userReward
+                        .mul(HUNDRED_PERCENT.sub(unlockImmediatelyPercent))
+                        .div(HUNDRED_PERCENT),
+                }
+            );
+        });
+
+        it("user should received the entire SOV rewards with 100% unlockedImmediatelyPercent", async () => {
+            const newUnlockedImmediatelyPercent = new BN(10000);
+            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
+
+            let depositTx = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            let depositBlockNumber = new BN(depositTx.receipt.blockNumber);
+            await SOVToken.transfer(liquidityMining.address, new BN(1000));
+
+            const previousUserSOVBalance = await SOVToken.balanceOf(account1);
+
+            let tx = await liquidityMining.claimReward(token1.address, ZERO_ADDRESS, {
+                from: account1,
+            });
+
+            let totalUsersBalance = await liquidityMining.totalUsersBalance();
+            expect(totalUsersBalance).bignumber.equal(new BN(0));
+
+            let poolInfo = await liquidityMining.getPoolInfo(token1.address);
+            let latestBlockNumber = new BN(tx.receipt.blockNumber);
+            checkPoolInfo(
+                poolInfo,
+                token1.address,
+                allocationPoint,
+                latestBlockNumber,
+                new BN(-1)
+            );
+
+            await checkUserPoolTokens(account1, token1, amount, amount, new BN(0));
+            let userReward = await checkUserReward(
+                account1,
+                token1,
+                depositBlockNumber,
+                latestBlockNumber
+            );
+
+            // withdrawAndStakeTokensFrom was invoked
+            let unlockedBalance = await lockedSOV.getUnlockedBalance(account1);
+            let lockedBalance = await lockedSOV.getLockedBalance(account1);
+            expect(unlockedBalance).bignumber.equal(new BN(0));
+            expect(lockedBalance).bignumber.equal(new BN(0));
+
+            const latestUserSOVBalance = await SOVToken.balanceOf(account1);
+
+            /** user should receive the entire SOV reward since the unlockedImmediatelyPercent is 100% */
+            expect(latestUserSOVBalance.toString()).to.equal(
+                previousUserSOVBalance.add(userReward)
+            );
+
+            expectEvent(tx, "RewardClaimed", {
+                user: account1,
+                poolToken: token1.address,
+                amount: userReward,
+            });
+        });
+
+        it("user should received the entire SOV rewards if unlockedImmediatelyOverwrite is set to 100%", async () => {
+            const newUnlockedImmediatelyPercentOverwrite = new BN(10000);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token1.address,
+                newUnlockedImmediatelyPercentOverwrite
+            );
+
+            let depositTx = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            let depositBlockNumber = new BN(depositTx.receipt.blockNumber);
+            await SOVToken.transfer(liquidityMining.address, new BN(1000));
+
+            const previousUserSOVBalance = await SOVToken.balanceOf(account1);
+
+            let tx = await liquidityMining.claimReward(token1.address, ZERO_ADDRESS, {
+                from: account1,
+            });
+
+            let totalUsersBalance = await liquidityMining.totalUsersBalance();
+            expect(totalUsersBalance).bignumber.equal(new BN(0));
+
+            let poolInfo = await liquidityMining.getPoolInfo(token1.address);
+            let latestBlockNumber = new BN(tx.receipt.blockNumber);
+            checkPoolInfo(
+                poolInfo,
+                token1.address,
+                allocationPoint,
+                latestBlockNumber,
+                new BN(-1)
+            );
+
+            await checkUserPoolTokens(account1, token1, amount, amount, new BN(0));
+            let userReward = await checkUserReward(
+                account1,
+                token1,
+                depositBlockNumber,
+                latestBlockNumber
+            );
+
+            // withdrawAndStakeTokensFrom was invoked
+            let unlockedBalance = await lockedSOV.getUnlockedBalance(account1);
+            let lockedBalance = await lockedSOV.getLockedBalance(account1);
+            expect(unlockedBalance).bignumber.equal(new BN(0));
+            expect(lockedBalance).bignumber.equal(new BN(0));
+
+            const latestUserSOVBalance = await SOVToken.balanceOf(account1);
+
+            /** user should receive the entire SOV reward since the unlockedImmediatelyPercent is 100% */
+            expect(latestUserSOVBalance.toString()).to.equal(
+                previousUserSOVBalance.add(userReward)
+            );
+
+            const unlockImmediatelyPercent =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(unlockImmediatelyPercent.toString()).to.equal(
+                newUnlockedImmediatelyPercentOverwrite.toString()
+            );
+
+            expectEvent(tx, "RewardClaimed", {
+                user: account1,
+                poolToken: token1.address,
+                amount: userReward,
+            });
+        });
+
+        it("user should received the entire SOV rewards if unlockedImmediatelyOverwrite is set to less than 100%", async () => {
+            // set the unlockedImmediatelyOverwrite to 30%
+            const newUnlockedImmediatelyPercentOverwrite = new BN(3000);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token1.address,
+                newUnlockedImmediatelyPercentOverwrite
+            );
+
+            let depositTx = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            let depositBlockNumber = new BN(depositTx.receipt.blockNumber);
+            await SOVToken.transfer(liquidityMining.address, new BN(1000));
+
+            const previousUserSOVBalance = await SOVToken.balanceOf(account1);
+
+            let tx = await liquidityMining.claimReward(token1.address, ZERO_ADDRESS, {
+                from: account1,
+            });
+
+            let totalUsersBalance = await liquidityMining.totalUsersBalance();
+            expect(totalUsersBalance).bignumber.equal(new BN(0));
+
+            let poolInfo = await liquidityMining.getPoolInfo(token1.address);
+            let latestBlockNumber = new BN(tx.receipt.blockNumber);
+            checkPoolInfo(
+                poolInfo,
+                token1.address,
+                allocationPoint,
+                latestBlockNumber,
+                new BN(-1)
+            );
+
+            await checkUserPoolTokens(account1, token1, amount, amount, new BN(0));
+            let userReward = await checkUserReward(
+                account1,
+                token1,
+                depositBlockNumber,
+                latestBlockNumber
+            );
+
+            // withdrawAndStakeTokensFrom was invoked
+            let unlockedBalance = await lockedSOV.getUnlockedBalance(account1);
+            let lockedBalance = await lockedSOV.getLockedBalance(account1);
+            expect(unlockedBalance).bignumber.equal(new BN(0));
+            expect(lockedBalance).bignumber.equal(new BN(0));
+
+            const latestUserSOVBalance = await SOVToken.balanceOf(account1);
+
+            /** user should only receive 10% SOV since the unlockedImmediatelyPercent is 30% */
+            const unlockImmediatelyPercent =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(unlockImmediatelyPercent.toString()).to.equal(
+                newUnlockedImmediatelyPercentOverwrite.toString()
+            );
+            expect(latestUserSOVBalance.toString()).to.equal(
+                previousUserSOVBalance.add(
+                    userReward.mul(unlockImmediatelyPercent).div(HUNDRED_PERCENT)
+                )
+            );
+
+            expectEvent(tx, "RewardClaimed", {
+                user: account1,
+                poolToken: token1.address,
+                amount: userReward,
+            });
+
+            // the other 70% of reward claimed will be staked
+            await expectEvent.inTransaction(
+                tx.receipt.rawLogs[0].transactionHash,
+                lockedSOV,
+                "TokensStaked",
+                {
+                    _initiator: account1,
+                    _vesting: ZERO_ADDRESS,
+                    _amount: userReward
+                        .mul(HUNDRED_PERCENT.sub(unlockImmediatelyPercent))
+                        .div(HUNDRED_PERCENT),
+                }
+            );
         });
 
         it("should be able to claim reward using wrapper", async () => {
@@ -836,7 +1196,7 @@ contract("LiquidityMining", (accounts) => {
             );
         });
 
-        it("should be able to claim reward (will be claimed with SOV tokens)", async () => {
+        it("should be able to claim all rewards (will be claimed with SOV tokens) with 10% of unlockedImmediatelyPercent", async () => {
             let depositTx1 = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
                 from: account1,
             });
@@ -846,6 +1206,8 @@ contract("LiquidityMining", (accounts) => {
             });
             let depositBlockNumber2 = new BN(depositTx2.receipt.blockNumber);
             await SOVToken.transfer(liquidityMining.address, amount.mul(new BN(2)));
+
+            const previousUserSOVBalance = await SOVToken.balanceOf(account1);
 
             let tx = await liquidityMining.claimRewardFromAllPools(ZERO_ADDRESS, {
                 from: account1,
@@ -890,11 +1252,343 @@ contract("LiquidityMining", (accounts) => {
             expect(unlockedBalance).bignumber.equal(new BN(0));
             expect(lockedBalance).bignumber.equal(new BN(0));
 
+            const latestUserSOVBalance = await SOVToken.balanceOf(account1);
+            const totalRewards = userReward1.add(userReward2);
+
+            /** user should only receive 10% SOV since the unlockedImmediatelyPercent is 10% */
+            const unlockImmediatelyPercent =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(latestUserSOVBalance.toString()).to.equal(
+                previousUserSOVBalance.add(
+                    totalRewards.mul(unlockImmediatelyPercent).div(HUNDRED_PERCENT)
+                )
+            );
+
             expectEvent(tx, "RewardClaimed", {
                 user: account1,
                 poolToken: token1.address,
                 amount: userReward1,
             });
+
+            // the other 90% of reward claimed will be staked
+            await expectEvent.inTransaction(
+                tx.receipt.rawLogs[0].transactionHash,
+                lockedSOV,
+                "TokensStaked",
+                {
+                    _initiator: account1,
+                    _vesting: ZERO_ADDRESS,
+                    _amount: totalRewards
+                        .mul(HUNDRED_PERCENT.sub(unlockImmediatelyPercent))
+                        .divRound(HUNDRED_PERCENT),
+                }
+            );
+
+            expect(userReward1, tx.logs[0].args.amount);
+            expect(token1.address, tx.logs[0].args.poolToken);
+            expect(userReward2, tx.logs[1].args.amount);
+            expect(token2.address, tx.logs[1].args.poolToken);
+        });
+
+        it("should be able to claim all rewards (will be claimed with SOV tokens) with 100% of unlockedImmediatelyPercent", async () => {
+            // set unlockedImmediatelyPercent to 100%
+            const newUnlockedImmediatelyPercent = new BN(10000);
+            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
+
+            let depositTx1 = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            let depositBlockNumber1 = new BN(depositTx1.receipt.blockNumber);
+            let depositTx2 = await liquidityMining.deposit(token2.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            let depositBlockNumber2 = new BN(depositTx2.receipt.blockNumber);
+            await SOVToken.transfer(liquidityMining.address, amount.mul(new BN(2)));
+
+            const previousUserSOVBalance = await SOVToken.balanceOf(account1);
+
+            let tx = await liquidityMining.claimRewardFromAllPools(ZERO_ADDRESS, {
+                from: account1,
+            });
+
+            let totalUsersBalance = await liquidityMining.totalUsersBalance();
+            expect(totalUsersBalance).bignumber.equal(new BN(0));
+
+            let poolInfo = await liquidityMining.getPoolInfo(token1.address);
+            let latestBlockNumber = new BN(tx.receipt.blockNumber);
+            checkPoolInfo(
+                poolInfo,
+                token1.address,
+                allocationPoint,
+                latestBlockNumber,
+                new BN(-1)
+            );
+
+            await checkUserPoolTokens(account1, token1, amount, amount, new BN(0));
+            let userReward1 = await checkUserReward(
+                account1,
+                token1,
+                depositBlockNumber1,
+                latestBlockNumber
+            );
+            // we have 2 pools with the same allocation points
+            userReward1 = userReward1.div(new BN(2));
+
+            await checkUserPoolTokens(account1, token2, amount, amount, new BN(0));
+            let userReward2 = await checkUserReward(
+                account1,
+                token2,
+                depositBlockNumber2,
+                latestBlockNumber
+            );
+            // we have 2 pools with the same allocation points
+            userReward2 = userReward2.div(new BN(2));
+
+            // withdrawAndStakeTokensFrom was invoked
+            let unlockedBalance = await lockedSOV.getUnlockedBalance(account1);
+            let lockedBalance = await lockedSOV.getLockedBalance(account1);
+            expect(unlockedBalance).bignumber.equal(new BN(0));
+            expect(lockedBalance).bignumber.equal(new BN(0));
+
+            const latestUserSOVBalance = await SOVToken.balanceOf(account1);
+            const totalRewards = userReward1.add(userReward2);
+
+            /** user should only receive 10% SOV since the unlockedImmediatelyPercent is 10% */
+            expect(latestUserSOVBalance.toString()).to.equal(
+                previousUserSOVBalance.add(totalRewards)
+            );
+
+            expectEvent(tx, "RewardClaimed", {
+                user: account1,
+                poolToken: token1.address,
+                amount: userReward1,
+            });
+
+            expect(userReward1, tx.logs[0].args.amount);
+            expect(token1.address, tx.logs[0].args.poolToken);
+            expect(userReward2, tx.logs[1].args.amount);
+            expect(token2.address, tx.logs[1].args.poolToken);
+        });
+
+        it("should be able to claim all rewards with combination of unlockedImmediatelyPercent (0% & 100%) among the pools", async () => {
+            // set unlockedImmediatelyPercent to 0%
+            const newUnlockedImmediatelyPercent = new BN(0);
+            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
+
+            // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
+            const newUnlockedImmediatelyPercentOverwrite = new BN(10000);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token2.address,
+                newUnlockedImmediatelyPercentOverwrite
+            );
+
+            const unlockImmediatelyPercentToken1 =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(unlockImmediatelyPercentToken1.toString()).to.equal(
+                newUnlockedImmediatelyPercent.toString()
+            );
+
+            const unlockImmediatelyPercentToken2 =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
+            expect(unlockImmediatelyPercentToken2.toString()).to.equal(
+                newUnlockedImmediatelyPercentOverwrite.toString()
+            );
+
+            let depositTx1 = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            let depositBlockNumber1 = new BN(depositTx1.receipt.blockNumber);
+            let depositTx2 = await liquidityMining.deposit(token2.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            let depositBlockNumber2 = new BN(depositTx2.receipt.blockNumber);
+            await SOVToken.transfer(liquidityMining.address, amount.mul(new BN(2)));
+
+            const previousUserSOVBalance = await SOVToken.balanceOf(account1);
+
+            let tx = await liquidityMining.claimRewardFromAllPools(ZERO_ADDRESS, {
+                from: account1,
+            });
+
+            let totalUsersBalance = await liquidityMining.totalUsersBalance();
+            expect(totalUsersBalance).bignumber.equal(new BN(0));
+
+            let poolInfo = await liquidityMining.getPoolInfo(token1.address);
+            let latestBlockNumber = new BN(tx.receipt.blockNumber);
+            checkPoolInfo(
+                poolInfo,
+                token1.address,
+                allocationPoint,
+                latestBlockNumber,
+                new BN(-1)
+            );
+
+            await checkUserPoolTokens(account1, token1, amount, amount, new BN(0));
+            let userReward1 = await checkUserReward(
+                account1,
+                token1,
+                depositBlockNumber1,
+                latestBlockNumber
+            );
+            // we have 2 pools with the same allocation points
+            userReward1 = userReward1.div(new BN(2));
+
+            await checkUserPoolTokens(account1, token2, amount, amount, new BN(0));
+            let userReward2 = await checkUserReward(
+                account1,
+                token2,
+                depositBlockNumber2,
+                latestBlockNumber
+            );
+            // we have 2 pools with the same allocation points
+            userReward2 = userReward2.div(new BN(2));
+
+            // withdrawAndStakeTokensFrom was invoked
+            let unlockedBalance = await lockedSOV.getUnlockedBalance(account1);
+            let lockedBalance = await lockedSOV.getLockedBalance(account1);
+            expect(unlockedBalance).bignumber.equal(new BN(0));
+            expect(lockedBalance).bignumber.equal(new BN(0));
+
+            const latestUserSOVBalance = await SOVToken.balanceOf(account1);
+            const totalRewards = userReward1.add(userReward2);
+
+            /** user should only receive reward2 since only pool token 2 unlock immediate percentage that was set to 100%*/
+            expect(latestUserSOVBalance.toString()).to.equal(
+                previousUserSOVBalance.add(userReward2)
+            );
+
+            expectEvent(tx, "RewardClaimed", {
+                user: account1,
+                poolToken: token1.address,
+                amount: userReward1,
+            });
+
+            // entire reward1 will be staked since we set the unlockedImmediatelyPercent to 0%
+            await expectEvent.inTransaction(
+                tx.receipt.rawLogs[0].transactionHash,
+                lockedSOV,
+                "TokensStaked",
+                {
+                    _initiator: account1,
+                    _vesting: ZERO_ADDRESS,
+                    _amount: userReward1,
+                }
+            );
+
+            expect(userReward1, tx.logs[0].args.amount);
+            expect(token1.address, tx.logs[0].args.poolToken);
+            expect(userReward2, tx.logs[1].args.amount);
+            expect(token2.address, tx.logs[1].args.poolToken);
+        });
+
+        it("should be able to claim all rewards with combination of unlockedImmediatelyPercent (30% & 100%) among the pools", async () => {
+            // set unlockedImmediatelyPercent to 0%
+            const newUnlockedImmediatelyPercent = new BN(3000);
+            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
+
+            // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
+            const newUnlockedImmediatelyPercentOverwrite = new BN(10000);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token2.address,
+                newUnlockedImmediatelyPercentOverwrite
+            );
+
+            const unlockImmediatelyPercentToken1 =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(unlockImmediatelyPercentToken1.toString()).to.equal(
+                newUnlockedImmediatelyPercent.toString()
+            );
+
+            const unlockImmediatelyPercentToken2 =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
+            expect(unlockImmediatelyPercentToken2.toString()).to.equal(
+                newUnlockedImmediatelyPercentOverwrite.toString()
+            );
+
+            let depositTx1 = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            let depositBlockNumber1 = new BN(depositTx1.receipt.blockNumber);
+            let depositTx2 = await liquidityMining.deposit(token2.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            let depositBlockNumber2 = new BN(depositTx2.receipt.blockNumber);
+            await SOVToken.transfer(liquidityMining.address, amount.mul(new BN(2)));
+
+            const previousUserSOVBalance = await SOVToken.balanceOf(account1);
+
+            let tx = await liquidityMining.claimRewardFromAllPools(ZERO_ADDRESS, {
+                from: account1,
+            });
+
+            let totalUsersBalance = await liquidityMining.totalUsersBalance();
+            expect(totalUsersBalance).bignumber.equal(new BN(0));
+
+            let poolInfo = await liquidityMining.getPoolInfo(token1.address);
+            let latestBlockNumber = new BN(tx.receipt.blockNumber);
+            checkPoolInfo(
+                poolInfo,
+                token1.address,
+                allocationPoint,
+                latestBlockNumber,
+                new BN(-1)
+            );
+
+            await checkUserPoolTokens(account1, token1, amount, amount, new BN(0));
+            let userReward1 = await checkUserReward(
+                account1,
+                token1,
+                depositBlockNumber1,
+                latestBlockNumber
+            );
+            // we have 2 pools with the same allocation points
+            userReward1 = userReward1.div(new BN(2));
+
+            await checkUserPoolTokens(account1, token2, amount, amount, new BN(0));
+            let userReward2 = await checkUserReward(
+                account1,
+                token2,
+                depositBlockNumber2,
+                latestBlockNumber
+            );
+            // we have 2 pools with the same allocation points
+            userReward2 = userReward2.div(new BN(2));
+
+            // withdrawAndStakeTokensFrom was invoked
+            let unlockedBalance = await lockedSOV.getUnlockedBalance(account1);
+            let lockedBalance = await lockedSOV.getLockedBalance(account1);
+            expect(unlockedBalance).bignumber.equal(new BN(0));
+            expect(lockedBalance).bignumber.equal(new BN(0));
+
+            const latestUserSOVBalance = await SOVToken.balanceOf(account1);
+            const totalRewards = userReward1.add(userReward2);
+
+            /** user should only receive (100% of reward2 + 30% of reward 1)*/
+            expect(latestUserSOVBalance.toString()).to.equal(
+                previousUserSOVBalance
+                    .add(userReward2)
+                    .add(userReward1.mul(unlockImmediatelyPercentToken1).div(HUNDRED_PERCENT))
+            );
+
+            expectEvent(tx, "RewardClaimed", {
+                user: account1,
+                poolToken: token1.address,
+                amount: userReward1,
+            });
+
+            // 70% reward1 will be staked since we set the unlockedImmediatelyPercent to 30%
+            await expectEvent.inTransaction(
+                tx.receipt.rawLogs[0].transactionHash,
+                lockedSOV,
+                "TokensStaked",
+                {
+                    _initiator: account1,
+                    _vesting: ZERO_ADDRESS,
+                    _amount: userReward1
+                        .mul(HUNDRED_PERCENT.sub(unlockImmediatelyPercentToken1))
+                        .divRound(HUNDRED_PERCENT),
+                }
+            );
 
             expect(userReward1, tx.logs[0].args.amount);
             expect(token1.address, tx.logs[0].args.poolToken);
@@ -2263,6 +2957,7 @@ contract("LiquidityMining", (accounts) => {
             depositBlockNumber,
             latestBlockNumber
         );
+
         let userReward = passedBlocks.mul(rewardTokensPerBlock);
         let userInfo = await liquidityMining.getUserInfo(poolToken.address, user);
         expect(userInfo.accumulatedReward).bignumber.equal(new BN(0));

--- a/tests/farm/LiquidityMining.js
+++ b/tests/farm/LiquidityMining.js
@@ -933,8 +933,9 @@ contract("LiquidityMining", (accounts) => {
             const latestUserSOVBalance = await SOVToken.balanceOf(account1);
 
             /** user should only receive 10% SOV since the unlockedImmediatelyPercent is 10% */
-            const unlockImmediatelyPercent =
-                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
+            const unlockImmediatelyPercent = await liquidityMining.calcUnlockedImmediatelyPercent(
+                token1.address
+            );
             expect(latestUserSOVBalance.toString()).to.equal(
                 previousUserSOVBalance.add(
                     userReward.mul(unlockImmediatelyPercent).div(HUNDRED_PERCENT)
@@ -1083,8 +1084,9 @@ contract("LiquidityMining", (accounts) => {
                 previousUserSOVBalance.add(userReward)
             );
 
-            const unlockImmediatelyPercent =
-                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
+            const unlockImmediatelyPercent = await liquidityMining.calcUnlockedImmediatelyPercent(
+                token1.address
+            );
             expect(unlockImmediatelyPercent.toString()).to.equal(
                 newpoolTokensUnlockedImmediatelyPercent.toString()
             );
@@ -1153,8 +1155,9 @@ contract("LiquidityMining", (accounts) => {
             const latestUserSOVBalance = await SOVToken.balanceOf(account1);
 
             /** user should only receive 10% SOV since the unlockedImmediatelyPercent is 30% */
-            const unlockImmediatelyPercent =
-                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
+            const unlockImmediatelyPercent = await liquidityMining.calcUnlockedImmediatelyPercent(
+                token1.address
+            );
             expect(unlockImmediatelyPercent.toString()).to.equal(
                 newpoolTokensUnlockedImmediatelyPercent.toString()
             );
@@ -1317,8 +1320,9 @@ contract("LiquidityMining", (accounts) => {
             const totalRewards = userReward1.add(userReward2);
 
             /** user should only receive 10% SOV since the unlockedImmediatelyPercent is 10% */
-            const unlockImmediatelyPercent =
-                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
+            const unlockImmediatelyPercent = await liquidityMining.calcUnlockedImmediatelyPercent(
+                token1.address
+            );
             expect(latestUserSOVBalance.toString()).to.equal(
                 previousUserSOVBalance.add(
                     totalRewards.mul(unlockImmediatelyPercent).div(HUNDRED_PERCENT)

--- a/tests/farm/LiquidityMining.js
+++ b/tests/farm/LiquidityMining.js
@@ -1624,6 +1624,188 @@ contract("LiquidityMining", (accounts) => {
             expect(unlockedBalance).bignumber.equal(new BN(0));
             expect(lockedBalance).bignumber.equal(new BN(0));
         });
+
+        it("getUserAccumulatedLiquidReward should return correct value", async () => {
+            await liquidityMining.add(token3.address, allocationPoint, false);
+            await token3.mint(account1, amount);
+            await token3.approve(liquidityMining.address, amount, { from: account1 });
+
+            // set unlockedImmediatelyPercent to 0%
+            const newUnlockedImmediatelyPercent = new BN(0);
+            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
+
+            // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
+            const newUnlockedImmediatelyPercentOverwrite2 = new BN(10000);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token2.address,
+                newUnlockedImmediatelyPercentOverwrite2
+            );
+
+            const newUnlockedImmediatelyPercentOverwrite3 = new BN(3000);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token3.address,
+                newUnlockedImmediatelyPercentOverwrite3
+            );
+
+            const unlockImmediatelyPercentToken1 =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(unlockImmediatelyPercentToken1.toString()).to.equal(
+                newUnlockedImmediatelyPercent.toString()
+            );
+
+            const unlockImmediatelyPercentToken2 =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
+            expect(unlockImmediatelyPercentToken2.toString()).to.equal(
+                newUnlockedImmediatelyPercentOverwrite2.toString()
+            );
+
+            const unlockImmediatelyPercentToken3 =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token3.address);
+            expect(unlockImmediatelyPercentToken3.toString()).to.equal(
+                newUnlockedImmediatelyPercentOverwrite3.toString()
+            );
+
+            await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            await liquidityMining.deposit(token2.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            await liquidityMining.deposit(token3.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            await SOVToken.transfer(liquidityMining.address, amount.mul(new BN(2)));
+
+            const peviousAccumulatedRewardList =
+                await liquidityMining.getUserAccumulatedRewardList(account1);
+            const previousAccumulatedLiquidReward =
+                await liquidityMining.getUserAccumulatedLiquidReward(account1);
+            expect(previousAccumulatedLiquidReward).to.be.an("array");
+            expect(previousAccumulatedLiquidReward[0]).to.equal(
+                unlockImmediatelyPercentToken1
+                    .mul(peviousAccumulatedRewardList[0])
+                    .div(HUNDRED_PERCENT)
+            );
+            expect(previousAccumulatedLiquidReward[1]).to.equal(
+                unlockImmediatelyPercentToken2
+                    .mul(peviousAccumulatedRewardList[1])
+                    .div(HUNDRED_PERCENT)
+            );
+            expect(previousAccumulatedLiquidReward[2]).to.equal(
+                unlockImmediatelyPercentToken3
+                    .mul(peviousAccumulatedRewardList[2])
+                    .div(HUNDRED_PERCENT)
+            );
+
+            await liquidityMining.claimRewardFromAllPools(ZERO_ADDRESS, {
+                from: account1,
+            });
+
+            const latestAccumulatedRewardList = await liquidityMining.getUserAccumulatedRewardList(
+                account1
+            );
+            expect(latestAccumulatedRewardList[0]).to.equal("0");
+            expect(latestAccumulatedRewardList[1]).to.equal("0");
+            expect(latestAccumulatedRewardList[2]).to.equal("0");
+
+            const latestAccumulatedLiquidReward =
+                await liquidityMining.getUserAccumulatedLiquidReward(account1);
+            expect(latestAccumulatedLiquidReward).to.be.an("array");
+            expect(latestAccumulatedLiquidReward[0]).to.equal("0");
+            expect(latestAccumulatedLiquidReward[1]).to.equal("0");
+            expect(latestAccumulatedLiquidReward[2]).to.equal("0");
+        });
+
+        it("getUserAccumulatedVestedReward should return correct value", async () => {
+            await liquidityMining.add(token3.address, allocationPoint, false);
+            await token3.mint(account1, amount);
+            await token3.approve(liquidityMining.address, amount, { from: account1 });
+
+            // set unlockedImmediatelyPercent to 0%
+            const newUnlockedImmediatelyPercent = new BN(0);
+            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
+
+            // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
+            const newUnlockedImmediatelyPercentOverwrite2 = new BN(10000);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token2.address,
+                newUnlockedImmediatelyPercentOverwrite2
+            );
+
+            const newUnlockedImmediatelyPercentOverwrite3 = new BN(3000);
+            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+                token3.address,
+                newUnlockedImmediatelyPercentOverwrite3
+            );
+
+            const unlockImmediatelyPercentToken1 =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+            expect(unlockImmediatelyPercentToken1.toString()).to.equal(
+                newUnlockedImmediatelyPercent.toString()
+            );
+
+            const unlockImmediatelyPercentToken2 =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
+            expect(unlockImmediatelyPercentToken2.toString()).to.equal(
+                newUnlockedImmediatelyPercentOverwrite2.toString()
+            );
+
+            const unlockImmediatelyPercentToken3 =
+                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token3.address);
+            expect(unlockImmediatelyPercentToken3.toString()).to.equal(
+                newUnlockedImmediatelyPercentOverwrite3.toString()
+            );
+
+            await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            await liquidityMining.deposit(token2.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            await liquidityMining.deposit(token3.address, amount, ZERO_ADDRESS, {
+                from: account1,
+            });
+            await SOVToken.transfer(liquidityMining.address, amount.mul(new BN(2)));
+
+            const peviousAccumulatedRewardList =
+                await liquidityMining.getUserAccumulatedRewardList(account1);
+            const previousAccumulatedVestedReward =
+                await liquidityMining.getUserAccumulatedVestedReward(account1);
+            expect(previousAccumulatedVestedReward).to.be.an("array");
+            expect(previousAccumulatedVestedReward[0]).to.equal(
+                HUNDRED_PERCENT.sub(unlockImmediatelyPercentToken1)
+                    .mul(peviousAccumulatedRewardList[0])
+                    .div(HUNDRED_PERCENT)
+            );
+            expect(previousAccumulatedVestedReward[1]).to.equal(
+                HUNDRED_PERCENT.sub(unlockImmediatelyPercentToken2)
+                    .mul(peviousAccumulatedRewardList[1])
+                    .div(HUNDRED_PERCENT)
+            );
+            expect(previousAccumulatedVestedReward[2]).to.equal(
+                HUNDRED_PERCENT.sub(unlockImmediatelyPercentToken3)
+                    .mul(peviousAccumulatedRewardList[2])
+                    .div(HUNDRED_PERCENT)
+            );
+
+            await liquidityMining.claimRewardFromAllPools(ZERO_ADDRESS, {
+                from: account1,
+            });
+
+            const latestAccumulatedRewardList = await liquidityMining.getUserAccumulatedRewardList(
+                account1
+            );
+            expect(latestAccumulatedRewardList[0]).to.equal("0");
+            expect(latestAccumulatedRewardList[1]).to.equal("0");
+            expect(latestAccumulatedRewardList[2]).to.equal("0");
+
+            const latestAccumulatedVestedReward =
+                await liquidityMining.getUserAccumulatedVestedReward(account1);
+            expect(latestAccumulatedVestedReward).to.be.an("array");
+            expect(latestAccumulatedVestedReward[0]).to.equal("0");
+            expect(latestAccumulatedVestedReward[1]).to.equal("0");
+            expect(latestAccumulatedVestedReward[2]).to.equal("0");
+        });
     });
 
     describe("withdraw", () => {

--- a/tests/farm/LiquidityMining.js
+++ b/tests/farm/LiquidityMining.js
@@ -316,6 +316,16 @@ contract("LiquidityMining", (accounts) => {
             expect(_unlockedImmediatelyPercent).bignumber.equal(newUnlockedImmediatelyPercent);
         });
 
+        // it should be possible for an admin to set unlockedImmediatelyPercent to 0%
+        it("successfully set to 0 (0%)", async () => {
+            let newUnlockedImmediatelyPercent = new BN(0);
+            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
+
+            let _unlockedImmediatelyPercent = await liquidityMining.unlockedImmediatelyPercent();
+            expect(_unlockedImmediatelyPercent).bignumber.equal(newUnlockedImmediatelyPercent);
+        });
+
+        // it should be possible for an admin to set unlockedImmediatelyPercent to 100%
         it("successfully set to 10000 (100%)", async () => {
             let newUnlockedImmediatelyPercent = new BN(10000);
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
@@ -324,6 +334,7 @@ contract("LiquidityMining", (accounts) => {
             expect(_unlockedImmediatelyPercent).bignumber.equal(newUnlockedImmediatelyPercent);
         });
 
+        // it should not be possible for any other address than owner / admin to set the unlockedImmediatelyPercent
         it("fails if not an owner or an admin", async () => {
             await deploymentAndInit();
             await expectRevert(
@@ -348,7 +359,7 @@ contract("LiquidityMining", (accounts) => {
             // should use unlockedImmediatelyPercent by default
             const unlockedImmediatelyPercent = await liquidityMining.unlockedImmediatelyPercent();
             let previousPoolTokenUnlockedImmediatelyPercent =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(previousPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
                 unlockedImmediatelyPercent
             );
@@ -367,18 +378,18 @@ contract("LiquidityMining", (accounts) => {
             );
 
             let latestPoolTokenUnlockedImmediatelyPercent =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(latestPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
                 newpoolTokensUnlockedImmediatelyPercent
             );
         });
 
         it("should use the unlockedImmediatelyPercent if poolTokensUnlockedImmediatelyPercent is updated to 0", async () => {
-            // getPoolTokenUnlockedImmediatelyPercent should use the poolTokensUnlockedImmediatelyPercent since it was set from the previous test
+            // calcUnlockedImmediatelyPercent should use the poolTokensUnlockedImmediatelyPercent since it was set from the previous test
             const poolTokensUnlockedImmediatelyPercent =
                 await liquidityMining.poolTokensUnlockedImmediatelyPercent(token1.address);
             const previousPoolTokenUnlockedImmediatelyPercent =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(previousPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
                 poolTokensUnlockedImmediatelyPercent
             );
@@ -390,10 +401,10 @@ contract("LiquidityMining", (accounts) => {
                 newpoolTokensUnlockedImmediatelyPercent
             );
 
-            // getPoolTokenUnlockedImmediatelyPercent should use the unlockedImmediatelyPercent
+            // calcUnlockedImmediatelyPercent should use the unlockedImmediatelyPercent
             const unlockedImmediatelyPercent = await liquidityMining.unlockedImmediatelyPercent();
             const latestPoolTokenUnlockedImmediatelyPercent =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(latestPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
                 unlockedImmediatelyPercent
             );
@@ -413,12 +424,28 @@ contract("LiquidityMining", (accounts) => {
             );
 
             let latestPoolTokenUnlockedImmediatelyPercent =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(latestPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
                 newpoolTokensUnlockedImmediatelyPercent
             );
         });
 
+        // it should be possible for an admin to set poolTokensUnlockedImmediatelyPercent to 0%
+        it("successfully set to 0 (0%)", async () => {
+            let newpoolTokensUnlockedImmediatelyPercent = new BN(0);
+            await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
+                token1.address,
+                newpoolTokensUnlockedImmediatelyPercent
+            );
+
+            let _poolTokensUnlockedImmediatelyPercent =
+                await liquidityMining.poolTokensUnlockedImmediatelyPercent(token1.address);
+            expect(_poolTokensUnlockedImmediatelyPercent).bignumber.equal(
+                newpoolTokensUnlockedImmediatelyPercent
+            );
+        });
+
+        // it should be possible for an admin to set poolTokensUnlockedImmediatelyPercent to 100%
         it("successfully set to 10000 (100%)", async () => {
             let newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
             await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
@@ -433,12 +460,13 @@ contract("LiquidityMining", (accounts) => {
             );
 
             let latestPoolTokenUnlockedImmediatelyPercent =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(latestPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
                 newpoolTokensUnlockedImmediatelyPercent
             );
         });
 
+        // it should not be possible for any other address than owner / admin to set the poolTokensUnlockedImmediatelyPercent
         it("fails if not an owner or an admin", async () => {
             await deploymentAndInit();
             await expectRevert(
@@ -855,6 +883,7 @@ contract("LiquidityMining", (accounts) => {
             );
         });
 
+        // if claiming rewards for single pool and 0% <unlockedImmediatelyPercent<100% and poolTokensUnlockedImmediatelyPercent is 0, unlockedImmediatelyPercent of the reward amount gets transferred to the user directly (through the lockedSOV contract) and 100% - unlockedImmediatelyPercent are vested
         it("should be able to claim reward (will be claimed with SOV tokens) with 10% of unlockedImmediatelyPercent", async () => {
             /**
              * unlockedImmediatelyPercent was set to 10%
@@ -905,7 +934,7 @@ contract("LiquidityMining", (accounts) => {
 
             /** user should only receive 10% SOV since the unlockedImmediatelyPercent is 10% */
             const unlockImmediatelyPercent =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(latestUserSOVBalance.toString()).to.equal(
                 previousUserSOVBalance.add(
                     userReward.mul(unlockImmediatelyPercent).div(HUNDRED_PERCENT)
@@ -933,7 +962,8 @@ contract("LiquidityMining", (accounts) => {
             );
         });
 
-        it("user should received the entire SOV rewards with 100% unlockedImmediatelyPercent", async () => {
+        // if claiming rewards for single pool and unlockedImmediatelyPercent is 100% and poolTokensUnlockedImmediatelyPercent is 0, the user receives 100% of the tokens directly to his wallet
+        it("user should receive the entire SOV rewards with 100% unlockedImmediatelyPercent", async () => {
             /**
              * set unlockedImmediatelyPercent to 100%
              * After user claim reward:
@@ -995,7 +1025,7 @@ contract("LiquidityMining", (accounts) => {
             });
         });
 
-        it("user should received the entire SOV rewards if unlockedImmediatelyOverwrite is set to 100%", async () => {
+        it("user should receive the entire SOV rewards if poolTokensUnlockedImmediatelyPercent is set to 100%", async () => {
             /**
              * set poolTokensUnlockedImmediatelyPercent to 100%
              * After user claim reward:
@@ -1054,7 +1084,7 @@ contract("LiquidityMining", (accounts) => {
             );
 
             const unlockImmediatelyPercent =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(unlockImmediatelyPercent.toString()).to.equal(
                 newpoolTokensUnlockedImmediatelyPercent.toString()
             );
@@ -1066,14 +1096,15 @@ contract("LiquidityMining", (accounts) => {
             });
         });
 
-        it("user should received the part of SOV rewards if unlockedImmediatelyOverwrite is set to less than 100%", async () => {
+        // if claiming rewards for a single pool and poolTokensUnlockedImmediatelyPercent > 0 and poolTokensUnlockedImmediatelyPercent != unlockedImmediatelyPercent, poolTokensUnlockedImmediatelyPercent of the reward amount gets transferred immediately to the user
+        it("user should receive the part of SOV rewards if poolTokensUnlockedImmediatelyPercent is set to less than 100%", async () => {
             /**
              * set poolTokensUnlockedImmediatelyPercent to 30%
              * After user claim reward:
              *      - 30% of token1 reward will be transferred directly to the user.
              *      - 70% of token1 reward will be vested.
              */
-            // set the unlockedImmediatelyOverwrite to 30%
+            // set the poolTokensUnlockedImmediatelyPercent to 30%
             const newpoolTokensUnlockedImmediatelyPercent = new BN(3000);
             await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token1.address,
@@ -1123,7 +1154,7 @@ contract("LiquidityMining", (accounts) => {
 
             /** user should only receive 10% SOV since the unlockedImmediatelyPercent is 30% */
             const unlockImmediatelyPercent =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(unlockImmediatelyPercent.toString()).to.equal(
                 newpoolTokensUnlockedImmediatelyPercent.toString()
             );
@@ -1287,7 +1318,7 @@ contract("LiquidityMining", (accounts) => {
 
             /** user should only receive 10% SOV since the unlockedImmediatelyPercent is 10% */
             const unlockImmediatelyPercent =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(latestUserSOVBalance.toString()).to.equal(
                 previousUserSOVBalance.add(
                     totalRewards.mul(unlockImmediatelyPercent).div(HUNDRED_PERCENT)
@@ -1320,6 +1351,7 @@ contract("LiquidityMining", (accounts) => {
             expect(token2.address, tx.logs[1].args.poolToken);
         });
 
+        // if the user only deposited into pool with 100% liquid rewards and claims rewards for all pools, the reward gets transferred immediately to the user and no vesting contract is created
         it("should be able to claim all rewards (will be claimed with SOV tokens) with 100% of unlockedImmediatelyPercent", async () => {
             /**
              * Set unlockedImmediatelyPercent to 100%
@@ -1406,6 +1438,7 @@ contract("LiquidityMining", (accounts) => {
             expect(token2.address, tx.logs[1].args.poolToken);
         });
 
+        // if the user has deposited at least 2 pool tokens and is claiming rewards for all pools and <unlockedImmediatelyPercent = 0 and one of the pools has poolTokensUnlockedImmediatelyPercent = 100%, the user should receive the rewards for that one pool liquid and the other one vested
         it("should be able to claim all rewards with combination of unlockedImmediatelyPercent (0% & 100%) among the pools", async () => {
             /**
              * Set unlockedImmediatelyPercent to 0% and poolTokensUnlockedImmediatelyPercent for token2 to 100%
@@ -1417,7 +1450,7 @@ contract("LiquidityMining", (accounts) => {
             const newUnlockedImmediatelyPercent = new BN(0);
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
 
-            // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
+            // set poolTokensUnlockedImmediatelyPercent for pool token 2 to 100%
             const newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
             await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token2.address,
@@ -1425,13 +1458,13 @@ contract("LiquidityMining", (accounts) => {
             );
 
             const unlockImmediatelyPercentToken1 =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(unlockImmediatelyPercentToken1.toString()).to.equal(
                 newUnlockedImmediatelyPercent.toString()
             );
 
             const unlockImmediatelyPercentToken2 =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token2.address);
             expect(unlockImmediatelyPercentToken2.toString()).to.equal(
                 newpoolTokensUnlockedImmediatelyPercent.toString()
             );
@@ -1534,7 +1567,7 @@ contract("LiquidityMining", (accounts) => {
             const newUnlockedImmediatelyPercent = new BN(3000);
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
 
-            // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
+            // set poolTokensUnlockedImmediatelyPercent for pool token 2 to 100%
             const newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
             await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token2.address,
@@ -1542,13 +1575,13 @@ contract("LiquidityMining", (accounts) => {
             );
 
             const unlockImmediatelyPercentToken1 =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(unlockImmediatelyPercentToken1.toString()).to.equal(
                 newUnlockedImmediatelyPercent.toString()
             );
 
             const unlockImmediatelyPercentToken2 =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token2.address);
             expect(unlockImmediatelyPercentToken2.toString()).to.equal(
                 newpoolTokensUnlockedImmediatelyPercent.toString()
             );
@@ -1672,7 +1705,8 @@ contract("LiquidityMining", (accounts) => {
             expect(lockedBalance).bignumber.equal(new BN(0));
         });
 
-        it("getUserAccumulatedLiquidReward should return correct value", async () => {
+        // getUserAccumulatedRewardToBePaidLiquid return the expected values if there are 3 pools of which 1 has poolTokensUnlockedImmediatelyPercent = 0, one has poolTokensUnlockedImmediatelyPercent = 30% and one has poolTokensUnlockedImmediatelyPercent = 100%. unlockedImmediatelyPercent is 0
+        it("getUserAccumulatedRewardToBePaidLiquid should return correct value", async () => {
             /**
              * 1. Register 3 tokens to LM
              * 2. Set the immediate percent
@@ -1680,12 +1714,12 @@ contract("LiquidityMining", (accounts) => {
              *      - Token 2: 100%
              *      - Token 3: 30%
              * 3. Deposit into LM for those 3 tokens
-             * 4. getUserAccumulatedLiquidReward should return SUM of these 3 rewards:
+             * 4. getUserAccumulatedRewardToBePaidLiquid should return SUM of these 3 rewards:
              *      - Token 1: 0% amount reward of token 1
              *      - Token 2: 100% amount reward of token 2
              *      - Token 3: 30% amount reward of token 3
              * 5. claim all rewards
-             * 6. getUserAccumulatedLiquidReward should return 0 value.
+             * 6. getUserAccumulatedRewardToBePaidLiquid should return 0 value.
              */
             await liquidityMining.add(token3.address, allocationPoint, false);
             await token3.mint(account1, amount);
@@ -1695,7 +1729,7 @@ contract("LiquidityMining", (accounts) => {
             const newUnlockedImmediatelyPercent = new BN(0);
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
 
-            // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
+            // set poolTokensUnlockedImmediatelyPercent for pool token 2 to 100%
             const newpoolTokensUnlockedImmediatelyPercent2 = new BN(10000);
             await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token2.address,
@@ -1709,19 +1743,19 @@ contract("LiquidityMining", (accounts) => {
             );
 
             const unlockImmediatelyPercentToken1 =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(unlockImmediatelyPercentToken1.toString()).to.equal(
                 newUnlockedImmediatelyPercent.toString()
             );
 
             const unlockImmediatelyPercentToken2 =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token2.address);
             expect(unlockImmediatelyPercentToken2.toString()).to.equal(
                 newpoolTokensUnlockedImmediatelyPercent2.toString()
             );
 
             const unlockImmediatelyPercentToken3 =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token3.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token3.address);
             expect(unlockImmediatelyPercentToken3.toString()).to.equal(
                 newpoolTokensUnlockedImmediatelyPercent3.toString()
             );
@@ -1740,7 +1774,7 @@ contract("LiquidityMining", (accounts) => {
             const peviousAccumulatedRewardList =
                 await liquidityMining.getUserAccumulatedRewardList(account1);
             const previousAccumulatedLiquidReward =
-                await liquidityMining.getUserAccumulatedLiquidReward(account1);
+                await liquidityMining.getUserAccumulatedRewardToBePaidLiquid(account1);
 
             const liquidRewardToken1 = unlockImmediatelyPercentToken1
                 .mul(peviousAccumulatedRewardList[0])
@@ -1767,11 +1801,12 @@ contract("LiquidityMining", (accounts) => {
             expect(latestAccumulatedRewardList[2]).to.equal("0");
 
             const latestAccumulatedLiquidReward =
-                await liquidityMining.getUserAccumulatedLiquidReward(account1);
+                await liquidityMining.getUserAccumulatedRewardToBePaidLiquid(account1);
             expect(latestAccumulatedLiquidReward).to.equal("0");
         });
 
-        it("getUserAccumulatedVestedReward should return correct value", async () => {
+        // getUserAccumulatedRewardToBeVested return the expected values if there are 3 pools of which 1 has poolTokensUnlockedImmediatelyPercent = 0, one has poolTokensUnlockedImmediatelyPercent = 30% and one has poolTokensUnlockedImmediatelyPercent = 100%. unlockedImmediatelyPercent is 0
+        it("getUserAccumulatedRewardToBeVested should return correct value", async () => {
             /**
              * 1. Register 3 tokens to LM
              * 2. Set the immediate percent
@@ -1779,12 +1814,12 @@ contract("LiquidityMining", (accounts) => {
              *      - Token 2: 100%
              *      - Token 3: 30%
              * 3. Deposit into LM for those 3 tokens
-             * 4. getUserAccumulatedVestedReward should return SUM of these 3 rewards:
+             * 4. getUserAccumulatedRewardToBeVested should return SUM of these 3 rewards:
              *      - Token 1: 100% amount reward of token 1
              *      - Token 2: 0% amount reward of token 2
              *      - Token 3: 70% amount reward of token 3
              * 5. claim all rewards
-             * 6. getUserAccumulatedVestedReward should return 0 value.
+             * 6. getUserAccumulatedRewardToBeVested should return 0 value.
              */
             await liquidityMining.add(token3.address, allocationPoint, false);
             await token3.mint(account1, amount);
@@ -1794,7 +1829,7 @@ contract("LiquidityMining", (accounts) => {
             const newUnlockedImmediatelyPercent = new BN(0);
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
 
-            // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
+            // set poolTokensUnlockedImmediatelyPercent for pool token 2 to 100%
             const newpoolTokensUnlockedImmediatelyPercent2 = new BN(10000);
             await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token2.address,
@@ -1808,19 +1843,19 @@ contract("LiquidityMining", (accounts) => {
             );
 
             const unlockImmediatelyPercentToken1 =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token1.address);
             expect(unlockImmediatelyPercentToken1.toString()).to.equal(
                 newUnlockedImmediatelyPercent.toString()
             );
 
             const unlockImmediatelyPercentToken2 =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token2.address);
             expect(unlockImmediatelyPercentToken2.toString()).to.equal(
                 newpoolTokensUnlockedImmediatelyPercent2.toString()
             );
 
             const unlockImmediatelyPercentToken3 =
-                await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token3.address);
+                await liquidityMining.calcUnlockedImmediatelyPercent(token3.address);
             expect(unlockImmediatelyPercentToken3.toString()).to.equal(
                 newpoolTokensUnlockedImmediatelyPercent3.toString()
             );
@@ -1839,7 +1874,7 @@ contract("LiquidityMining", (accounts) => {
             const peviousAccumulatedRewardList =
                 await liquidityMining.getUserAccumulatedRewardList(account1);
             const previousAccumulatedVestedReward =
-                await liquidityMining.getUserAccumulatedVestedReward(account1);
+                await liquidityMining.getUserAccumulatedRewardToBeVested(account1);
 
             const vestedRewardToken1 = HUNDRED_PERCENT.sub(unlockImmediatelyPercentToken1)
                 .mul(peviousAccumulatedRewardList[0])
@@ -1866,7 +1901,7 @@ contract("LiquidityMining", (accounts) => {
             expect(latestAccumulatedRewardList[2]).to.equal("0");
 
             const latestAccumulatedVestedReward =
-                await liquidityMining.getUserAccumulatedVestedReward(account1);
+                await liquidityMining.getUserAccumulatedRewardToBeVested(account1);
             expect(latestAccumulatedVestedReward).to.equal("0");
         });
     });

--- a/tests/farm/LiquidityMining.js
+++ b/tests/farm/LiquidityMining.js
@@ -856,6 +856,12 @@ contract("LiquidityMining", (accounts) => {
         });
 
         it("should be able to claim reward (will be claimed with SOV tokens) with 10% of unlockedImmediatelyPercent", async () => {
+            /**
+             * unlockedImmediatelyPercent was set to 10%
+             * After user claim reward:
+             *      - 10% of token1 reward will be transferred directly to the user.
+             *      - 90% of token1 reward will be vested.
+             */
             let depositTx = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
                 from: account1,
             });
@@ -928,6 +934,11 @@ contract("LiquidityMining", (accounts) => {
         });
 
         it("user should received the entire SOV rewards with 100% unlockedImmediatelyPercent", async () => {
+            /**
+             * set unlockedImmediatelyPercent to 100%
+             * After user claim reward:
+             *      - 100% of token1 reward will be transferred directly to the user.
+             */
             const newUnlockedImmediatelyPercent = new BN(10000);
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
 
@@ -985,6 +996,11 @@ contract("LiquidityMining", (accounts) => {
         });
 
         it("user should received the entire SOV rewards if unlockedImmediatelyOverwrite is set to 100%", async () => {
+            /**
+             * set unlockedImmediatelyPercentOverwrite to 100%
+             * After user claim reward:
+             *      - 100% of token1 reward will be transferred directly to the user.
+             */
             const newUnlockedImmediatelyPercentOverwrite = new BN(10000);
             await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
                 token1.address,
@@ -1050,7 +1066,13 @@ contract("LiquidityMining", (accounts) => {
             });
         });
 
-        it("user should received the entire SOV rewards if unlockedImmediatelyOverwrite is set to less than 100%", async () => {
+        it("user should received the part of SOV rewards if unlockedImmediatelyOverwrite is set to less than 100%", async () => {
+            /**
+             * set unlockedImmediatelyPercentOverwrite to 30%
+             * After user claim reward:
+             *      - 30% of token1 reward will be transferred directly to the user.
+             *      - 70% of token1 reward will be vested.
+             */
             // set the unlockedImmediatelyOverwrite to 30%
             const newUnlockedImmediatelyPercentOverwrite = new BN(3000);
             await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
@@ -1197,6 +1219,14 @@ contract("LiquidityMining", (accounts) => {
         });
 
         it("should be able to claim all rewards (will be claimed with SOV tokens) with 10% of unlockedImmediatelyPercent", async () => {
+            /**
+             * unlockedImmediatelyPercent was to 10%
+             * After user claim all rewards:
+             *      - 10% of token1 reward will be transferred directly to the user.
+             *      - 90% of token1 reward will be vested.
+             *      - 10% of token2 reward will be transferred directly to the user.
+             *      - 90% of token2 reward will be vested.
+             */
             let depositTx1 = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
                 from: account1,
             });
@@ -1291,6 +1321,12 @@ contract("LiquidityMining", (accounts) => {
         });
 
         it("should be able to claim all rewards (will be claimed with SOV tokens) with 100% of unlockedImmediatelyPercent", async () => {
+            /**
+             * Set unlockedImmediatelyPercent to 100%
+             * After user claim all rewards:
+             *      - 100% of token1 reward will be transferred directly to the user.
+             *      - 100% of token2 reward will be transferred directly to the user.
+             */
             // set unlockedImmediatelyPercent to 100%
             const newUnlockedImmediatelyPercent = new BN(10000);
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
@@ -1371,6 +1407,12 @@ contract("LiquidityMining", (accounts) => {
         });
 
         it("should be able to claim all rewards with combination of unlockedImmediatelyPercent (0% & 100%) among the pools", async () => {
+            /**
+             * Set unlockedImmediatelyPercent to 0% and unlockedImmediatelyPercentOverwrite for token2 to 100%
+             * After user claim all rewards:
+             *      - 100% of token1 reward will be vested.
+             *      - 100% of token2 reward will be transferred directly to the user.
+             */
             // set unlockedImmediatelyPercent to 0%
             const newUnlockedImmediatelyPercent = new BN(0);
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
@@ -1450,7 +1492,6 @@ contract("LiquidityMining", (accounts) => {
             expect(lockedBalance).bignumber.equal(new BN(0));
 
             const latestUserSOVBalance = await SOVToken.balanceOf(account1);
-            const totalRewards = userReward1.add(userReward2);
 
             /** user should only receive reward2 since only pool token 2 unlock immediate percentage that was set to 100%*/
             expect(latestUserSOVBalance.toString()).to.equal(
@@ -1482,6 +1523,13 @@ contract("LiquidityMining", (accounts) => {
         });
 
         it("should be able to claim all rewards with combination of unlockedImmediatelyPercent (30% & 100%) among the pools", async () => {
+            /**
+             * Set unlockedImmediatelyPercent to 30% and unlockedImmediatelyPercentOverwrite for token2 to 100%
+             * After user claim all rewards:
+             *      - 70% of token1 reward will be vested.
+             *      - 30% of token1 reward will be transferred directly to the user.
+             *      - 100% of token2 reward will be transferred directly to the user.
+             */
             // set unlockedImmediatelyPercent to 0%
             const newUnlockedImmediatelyPercent = new BN(3000);
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
@@ -1561,7 +1609,6 @@ contract("LiquidityMining", (accounts) => {
             expect(lockedBalance).bignumber.equal(new BN(0));
 
             const latestUserSOVBalance = await SOVToken.balanceOf(account1);
-            const totalRewards = userReward1.add(userReward2);
 
             /** user should only receive (100% of reward2 + 30% of reward 1)*/
             expect(latestUserSOVBalance.toString()).to.equal(
@@ -1626,6 +1673,20 @@ contract("LiquidityMining", (accounts) => {
         });
 
         it("getUserAccumulatedLiquidReward should return correct value", async () => {
+            /**
+             * 1. Register 3 tokens to LM
+             * 2. Set the immediate percent
+             *      - Token 1: 0%
+             *      - Token 2: 100%
+             *      - Token 3: 30%
+             * 3. Deposit into LM for those 3 tokens
+             * 4. getUserAccumulatedLiquidReward should return array that consist of:
+             *      - Token 1: 0% amount reward of token 1
+             *      - Token 2: 100% amount reward of token 2
+             *      - Token 3: 30% amount reward of token 3
+             * 5. claim all rewards
+             * 6. getUserAccumulatedLiquidReward should return 0 value for all of those 3 tokens.
+             */
             await liquidityMining.add(token3.address, allocationPoint, false);
             await token3.mint(account1, amount);
             await token3.approve(liquidityMining.address, amount, { from: account1 });
@@ -1717,6 +1778,20 @@ contract("LiquidityMining", (accounts) => {
         });
 
         it("getUserAccumulatedVestedReward should return correct value", async () => {
+            /**
+             * 1. Register 3 tokens to LM
+             * 2. Set the immediate percent
+             *      - Token 1: 0%
+             *      - Token 2: 100%
+             *      - Token 3: 30%
+             * 3. Deposit into LM for those 3 tokens
+             * 4. getUserAccumulatedVestedReward should return array that consist of:
+             *      - Token 1: 100% amount reward of token 1
+             *      - Token 2: 0% amount reward of token 2
+             *      - Token 3: 70% amount reward of token 3
+             * 5. claim all rewards
+             * 6. getUserAccumulatedVestedReward should return 0 value for all of those 3 tokens.
+             */
             await liquidityMining.add(token3.address, allocationPoint, false);
             await token3.mint(account1, amount);
             await token3.approve(liquidityMining.address, amount, { from: account1 });

--- a/tests/farm/LiquidityMining.js
+++ b/tests/farm/LiquidityMining.js
@@ -343,8 +343,8 @@ contract("LiquidityMining", (accounts) => {
         });
     });
 
-    describe("setUnlockedImmediatelyPercentOverwrite", () => {
-        it("should use the unlockedImmediatelyPercentOverwrite by default", async () => {
+    describe("setPoolTokensUnlockedImmediatelyPercent", () => {
+        it("should use the poolTokensUnlockedImmediatelyPercent by default", async () => {
             // should use unlockedImmediatelyPercent by default
             const unlockedImmediatelyPercent = await liquidityMining.unlockedImmediatelyPercent();
             let previousPoolTokenUnlockedImmediatelyPercent =
@@ -353,41 +353,41 @@ contract("LiquidityMining", (accounts) => {
                 unlockedImmediatelyPercent
             );
 
-            // set the unlockedImmediatelyPercentOverwrite
-            let newUnlockedImmediatelyPercentOverwrite = new BN(3000);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            // set the poolTokensUnlockedImmediatelyPercent
+            let newpoolTokensUnlockedImmediatelyPercent = new BN(3000);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token1.address,
-                newUnlockedImmediatelyPercentOverwrite
+                newpoolTokensUnlockedImmediatelyPercent
             );
 
-            let _unlockedImmediatelyPercentOverwrite =
-                await liquidityMining.unlockedImmediatelyPercentOverwrite(token1.address);
-            expect(_unlockedImmediatelyPercentOverwrite).bignumber.equal(
-                newUnlockedImmediatelyPercentOverwrite
+            let _poolTokensUnlockedImmediatelyPercent =
+                await liquidityMining.poolTokensUnlockedImmediatelyPercent(token1.address);
+            expect(_poolTokensUnlockedImmediatelyPercent).bignumber.equal(
+                newpoolTokensUnlockedImmediatelyPercent
             );
 
             let latestPoolTokenUnlockedImmediatelyPercent =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
             expect(latestPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
-                newUnlockedImmediatelyPercentOverwrite
+                newpoolTokensUnlockedImmediatelyPercent
             );
         });
 
-        it("should use the unlockedImmediatelyPercent if unlockedImmediatelyPercentOverwrite is updated to 0", async () => {
-            // getPoolTokenUnlockedImmediatelyPercent should use the unlockedImmediatelyPercentOverwrite since it was set from the previous test
-            const unlockedImmediatelyPercentOverwrite =
-                await liquidityMining.unlockedImmediatelyPercentOverwrite(token1.address);
+        it("should use the unlockedImmediatelyPercent if poolTokensUnlockedImmediatelyPercent is updated to 0", async () => {
+            // getPoolTokenUnlockedImmediatelyPercent should use the poolTokensUnlockedImmediatelyPercent since it was set from the previous test
+            const poolTokensUnlockedImmediatelyPercent =
+                await liquidityMining.poolTokensUnlockedImmediatelyPercent(token1.address);
             const previousPoolTokenUnlockedImmediatelyPercent =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
             expect(previousPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
-                unlockedImmediatelyPercentOverwrite
+                poolTokensUnlockedImmediatelyPercent
             );
 
-            // set the unlockedImmediatelyPercentOverwrite to 0
-            newUnlockedImmediatelyPercentOverwrite = new BN(0);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            // set the poolTokensUnlockedImmediatelyPercent to 0
+            newpoolTokensUnlockedImmediatelyPercent = new BN(0);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token1.address,
-                newUnlockedImmediatelyPercentOverwrite
+                newpoolTokensUnlockedImmediatelyPercent
             );
 
             // getPoolTokenUnlockedImmediatelyPercent should use the unlockedImmediatelyPercent
@@ -400,63 +400,63 @@ contract("LiquidityMining", (accounts) => {
         });
 
         it("sets the expected values", async () => {
-            let newUnlockedImmediatelyPercentOverwrite = new BN(2000);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            let newpoolTokensUnlockedImmediatelyPercent = new BN(2000);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token1.address,
-                newUnlockedImmediatelyPercentOverwrite
+                newpoolTokensUnlockedImmediatelyPercent
             );
 
-            let _unlockedImmediatelyPercentOverwrite =
-                await liquidityMining.unlockedImmediatelyPercentOverwrite(token1.address);
-            expect(_unlockedImmediatelyPercentOverwrite).bignumber.equal(
-                newUnlockedImmediatelyPercentOverwrite
+            let _poolTokensUnlockedImmediatelyPercent =
+                await liquidityMining.poolTokensUnlockedImmediatelyPercent(token1.address);
+            expect(_poolTokensUnlockedImmediatelyPercent).bignumber.equal(
+                newpoolTokensUnlockedImmediatelyPercent
             );
 
             let latestPoolTokenUnlockedImmediatelyPercent =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
             expect(latestPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
-                newUnlockedImmediatelyPercentOverwrite
+                newpoolTokensUnlockedImmediatelyPercent
             );
         });
 
         it("successfully set to 10000 (100%)", async () => {
-            let newUnlockedImmediatelyPercentOverwrite = new BN(10000);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            let newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token1.address,
-                newUnlockedImmediatelyPercentOverwrite
+                newpoolTokensUnlockedImmediatelyPercent
             );
 
-            let _unlockedImmediatelyPercentOverwrite =
-                await liquidityMining.unlockedImmediatelyPercentOverwrite(token1.address);
-            expect(_unlockedImmediatelyPercentOverwrite).bignumber.equal(
-                newUnlockedImmediatelyPercentOverwrite
+            let _poolTokensUnlockedImmediatelyPercent =
+                await liquidityMining.poolTokensUnlockedImmediatelyPercent(token1.address);
+            expect(_poolTokensUnlockedImmediatelyPercent).bignumber.equal(
+                newpoolTokensUnlockedImmediatelyPercent
             );
 
             let latestPoolTokenUnlockedImmediatelyPercent =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
             expect(latestPoolTokenUnlockedImmediatelyPercent).bignumber.equal(
-                newUnlockedImmediatelyPercentOverwrite
+                newpoolTokensUnlockedImmediatelyPercent
             );
         });
 
         it("fails if not an owner or an admin", async () => {
             await deploymentAndInit();
             await expectRevert(
-                liquidityMining.setUnlockedImmediatelyPercentOverwrite(token1.address, 1000, {
+                liquidityMining.setPoolTokensUnlockedImmediatelyPercent(token1.address, 1000, {
                     from: account1,
                 }),
                 "unauthorized"
             );
 
             await liquidityMining.addAdmin(account1);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(token1.address, 1000, {
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(token1.address, 1000, {
                 from: account1,
             });
         });
 
         it("fails if unlockedImmediatelyPercent > 10000", async () => {
             await expectRevert(
-                liquidityMining.setUnlockedImmediatelyPercentOverwrite(token1.address, 10001),
+                liquidityMining.setPoolTokensUnlockedImmediatelyPercent(token1.address, 10001),
                 "Unlocked immediately percent has to be less than equal to 10000."
             );
         });
@@ -997,14 +997,14 @@ contract("LiquidityMining", (accounts) => {
 
         it("user should received the entire SOV rewards if unlockedImmediatelyOverwrite is set to 100%", async () => {
             /**
-             * set unlockedImmediatelyPercentOverwrite to 100%
+             * set poolTokensUnlockedImmediatelyPercent to 100%
              * After user claim reward:
              *      - 100% of token1 reward will be transferred directly to the user.
              */
-            const newUnlockedImmediatelyPercentOverwrite = new BN(10000);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            const newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token1.address,
-                newUnlockedImmediatelyPercentOverwrite
+                newpoolTokensUnlockedImmediatelyPercent
             );
 
             let depositTx = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
@@ -1056,7 +1056,7 @@ contract("LiquidityMining", (accounts) => {
             const unlockImmediatelyPercent =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
             expect(unlockImmediatelyPercent.toString()).to.equal(
-                newUnlockedImmediatelyPercentOverwrite.toString()
+                newpoolTokensUnlockedImmediatelyPercent.toString()
             );
 
             expectEvent(tx, "RewardClaimed", {
@@ -1068,16 +1068,16 @@ contract("LiquidityMining", (accounts) => {
 
         it("user should received the part of SOV rewards if unlockedImmediatelyOverwrite is set to less than 100%", async () => {
             /**
-             * set unlockedImmediatelyPercentOverwrite to 30%
+             * set poolTokensUnlockedImmediatelyPercent to 30%
              * After user claim reward:
              *      - 30% of token1 reward will be transferred directly to the user.
              *      - 70% of token1 reward will be vested.
              */
             // set the unlockedImmediatelyOverwrite to 30%
-            const newUnlockedImmediatelyPercentOverwrite = new BN(3000);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            const newpoolTokensUnlockedImmediatelyPercent = new BN(3000);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token1.address,
-                newUnlockedImmediatelyPercentOverwrite
+                newpoolTokensUnlockedImmediatelyPercent
             );
 
             let depositTx = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
@@ -1125,7 +1125,7 @@ contract("LiquidityMining", (accounts) => {
             const unlockImmediatelyPercent =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token1.address);
             expect(unlockImmediatelyPercent.toString()).to.equal(
-                newUnlockedImmediatelyPercentOverwrite.toString()
+                newpoolTokensUnlockedImmediatelyPercent.toString()
             );
             expect(latestUserSOVBalance.toString()).to.equal(
                 previousUserSOVBalance.add(
@@ -1408,7 +1408,7 @@ contract("LiquidityMining", (accounts) => {
 
         it("should be able to claim all rewards with combination of unlockedImmediatelyPercent (0% & 100%) among the pools", async () => {
             /**
-             * Set unlockedImmediatelyPercent to 0% and unlockedImmediatelyPercentOverwrite for token2 to 100%
+             * Set unlockedImmediatelyPercent to 0% and poolTokensUnlockedImmediatelyPercent for token2 to 100%
              * After user claim all rewards:
              *      - 100% of token1 reward will be vested.
              *      - 100% of token2 reward will be transferred directly to the user.
@@ -1418,10 +1418,10 @@ contract("LiquidityMining", (accounts) => {
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
 
             // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
-            const newUnlockedImmediatelyPercentOverwrite = new BN(10000);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            const newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token2.address,
-                newUnlockedImmediatelyPercentOverwrite
+                newpoolTokensUnlockedImmediatelyPercent
             );
 
             const unlockImmediatelyPercentToken1 =
@@ -1433,7 +1433,7 @@ contract("LiquidityMining", (accounts) => {
             const unlockImmediatelyPercentToken2 =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
             expect(unlockImmediatelyPercentToken2.toString()).to.equal(
-                newUnlockedImmediatelyPercentOverwrite.toString()
+                newpoolTokensUnlockedImmediatelyPercent.toString()
             );
 
             let depositTx1 = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
@@ -1524,7 +1524,7 @@ contract("LiquidityMining", (accounts) => {
 
         it("should be able to claim all rewards with combination of unlockedImmediatelyPercent (30% & 100%) among the pools", async () => {
             /**
-             * Set unlockedImmediatelyPercent to 30% and unlockedImmediatelyPercentOverwrite for token2 to 100%
+             * Set unlockedImmediatelyPercent to 30% and poolTokensUnlockedImmediatelyPercent for token2 to 100%
              * After user claim all rewards:
              *      - 70% of token1 reward will be vested.
              *      - 30% of token1 reward will be transferred directly to the user.
@@ -1535,10 +1535,10 @@ contract("LiquidityMining", (accounts) => {
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
 
             // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
-            const newUnlockedImmediatelyPercentOverwrite = new BN(10000);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            const newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token2.address,
-                newUnlockedImmediatelyPercentOverwrite
+                newpoolTokensUnlockedImmediatelyPercent
             );
 
             const unlockImmediatelyPercentToken1 =
@@ -1550,7 +1550,7 @@ contract("LiquidityMining", (accounts) => {
             const unlockImmediatelyPercentToken2 =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
             expect(unlockImmediatelyPercentToken2.toString()).to.equal(
-                newUnlockedImmediatelyPercentOverwrite.toString()
+                newpoolTokensUnlockedImmediatelyPercent.toString()
             );
 
             let depositTx1 = await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
@@ -1696,16 +1696,16 @@ contract("LiquidityMining", (accounts) => {
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
 
             // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
-            const newUnlockedImmediatelyPercentOverwrite2 = new BN(10000);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            const newpoolTokensUnlockedImmediatelyPercent2 = new BN(10000);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token2.address,
-                newUnlockedImmediatelyPercentOverwrite2
+                newpoolTokensUnlockedImmediatelyPercent2
             );
 
-            const newUnlockedImmediatelyPercentOverwrite3 = new BN(3000);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            const newpoolTokensUnlockedImmediatelyPercent3 = new BN(3000);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token3.address,
-                newUnlockedImmediatelyPercentOverwrite3
+                newpoolTokensUnlockedImmediatelyPercent3
             );
 
             const unlockImmediatelyPercentToken1 =
@@ -1717,13 +1717,13 @@ contract("LiquidityMining", (accounts) => {
             const unlockImmediatelyPercentToken2 =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
             expect(unlockImmediatelyPercentToken2.toString()).to.equal(
-                newUnlockedImmediatelyPercentOverwrite2.toString()
+                newpoolTokensUnlockedImmediatelyPercent2.toString()
             );
 
             const unlockImmediatelyPercentToken3 =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token3.address);
             expect(unlockImmediatelyPercentToken3.toString()).to.equal(
-                newUnlockedImmediatelyPercentOverwrite3.toString()
+                newpoolTokensUnlockedImmediatelyPercent3.toString()
             );
 
             await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {
@@ -1795,16 +1795,16 @@ contract("LiquidityMining", (accounts) => {
             await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
 
             // set unlockedImmediatelyPercentOverview for pool token 2 to 100%
-            const newUnlockedImmediatelyPercentOverwrite2 = new BN(10000);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            const newpoolTokensUnlockedImmediatelyPercent2 = new BN(10000);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token2.address,
-                newUnlockedImmediatelyPercentOverwrite2
+                newpoolTokensUnlockedImmediatelyPercent2
             );
 
-            const newUnlockedImmediatelyPercentOverwrite3 = new BN(3000);
-            await liquidityMining.setUnlockedImmediatelyPercentOverwrite(
+            const newpoolTokensUnlockedImmediatelyPercent3 = new BN(3000);
+            await liquidityMining.setPoolTokensUnlockedImmediatelyPercent(
                 token3.address,
-                newUnlockedImmediatelyPercentOverwrite3
+                newpoolTokensUnlockedImmediatelyPercent3
             );
 
             const unlockImmediatelyPercentToken1 =
@@ -1816,13 +1816,13 @@ contract("LiquidityMining", (accounts) => {
             const unlockImmediatelyPercentToken2 =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token2.address);
             expect(unlockImmediatelyPercentToken2.toString()).to.equal(
-                newUnlockedImmediatelyPercentOverwrite2.toString()
+                newpoolTokensUnlockedImmediatelyPercent2.toString()
             );
 
             const unlockImmediatelyPercentToken3 =
                 await liquidityMining.getPoolTokenUnlockedImmediatelyPercent(token3.address);
             expect(unlockImmediatelyPercentToken3.toString()).to.equal(
-                newUnlockedImmediatelyPercentOverwrite3.toString()
+                newpoolTokensUnlockedImmediatelyPercent3.toString()
             );
 
             await liquidityMining.deposit(token1.address, amount, ZERO_ADDRESS, {

--- a/tests/farm/LiquidityMining.js
+++ b/tests/farm/LiquidityMining.js
@@ -48,7 +48,7 @@ contract("LiquidityMining", (accounts) => {
     /// @dev 10000 is 100%
     const unlockedImmediatelyPercent = new BN(1000); // 10%
 
-    let root, account1, account2, account3, account4;
+    let root, account1, account2, account3, account4, lmAdmin;
     let SOVToken, token1, token2, token3, liquidityMiningConfigToken;
     let liquidityMining, wrapper;
     let lockedSOVAdmins, lockedSOV;
@@ -81,7 +81,7 @@ contract("LiquidityMining", (accounts) => {
 
     before(async () => {
         accounts = await web3.eth.getAccounts();
-        [root, account1, account2, account3, account4, ...accounts] = accounts;
+        [root, account1, account2, account3, account4, lmAdmin, ...accounts] = accounts;
     });
 
     /// @dev Test dummy liquidityMiningConfigToken methods for coverage
@@ -318,8 +318,11 @@ contract("LiquidityMining", (accounts) => {
 
         // it should be possible for an admin to set unlockedImmediatelyPercent to 0%
         it("successfully set to 0 (0%)", async () => {
+            await liquidityMining.addAdmin(lmAdmin);
             let newUnlockedImmediatelyPercent = new BN(0);
-            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
+            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent, {
+                from: lmAdmin,
+            });
 
             let _unlockedImmediatelyPercent = await liquidityMining.unlockedImmediatelyPercent();
             expect(_unlockedImmediatelyPercent).bignumber.equal(newUnlockedImmediatelyPercent);
@@ -327,8 +330,11 @@ contract("LiquidityMining", (accounts) => {
 
         // it should be possible for an admin to set unlockedImmediatelyPercent to 100%
         it("successfully set to 10000 (100%)", async () => {
+            await liquidityMining.addAdmin(lmAdmin);
             let newUnlockedImmediatelyPercent = new BN(10000);
-            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent);
+            await liquidityMining.setUnlockedImmediatelyPercent(newUnlockedImmediatelyPercent, {
+                from: lmAdmin,
+            });
 
             let _unlockedImmediatelyPercent = await liquidityMining.unlockedImmediatelyPercent();
             expect(_unlockedImmediatelyPercent).bignumber.equal(newUnlockedImmediatelyPercent);
@@ -432,10 +438,12 @@ contract("LiquidityMining", (accounts) => {
 
         // it should be possible for an admin to set poolTokensUnlockedImmediatelyPercent to 0%
         it("successfully set to 0 (0%)", async () => {
+            await liquidityMining.addAdmin(lmAdmin);
             let newpoolTokensUnlockedImmediatelyPercent = new BN(0);
             await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token1.address,
-                newpoolTokensUnlockedImmediatelyPercent
+                newpoolTokensUnlockedImmediatelyPercent,
+                { from: lmAdmin }
             );
 
             let _poolTokensUnlockedImmediatelyPercent =
@@ -447,10 +455,12 @@ contract("LiquidityMining", (accounts) => {
 
         // it should be possible for an admin to set poolTokensUnlockedImmediatelyPercent to 100%
         it("successfully set to 10000 (100%)", async () => {
+            await liquidityMining.addAdmin(lmAdmin);
             let newpoolTokensUnlockedImmediatelyPercent = new BN(10000);
             await liquidityMining.setPoolTokenUnlockedImmediatelyPercent(
                 token1.address,
-                newpoolTokensUnlockedImmediatelyPercent
+                newpoolTokensUnlockedImmediatelyPercent,
+                { from: lmAdmin }
             );
 
             let _poolTokensUnlockedImmediatelyPercent =


### PR DESCRIPTION
https://sovryn.atlassian.net/browse/SOV-1983
Enable The LM rewards contract to support individually adjusting the split of liquid/vested rewards such that a pool can have 100% liquid LM rewards